### PR TITLE
AudioManager Issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .idea/
-.git/
 docs/
 recordings/
 target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,27 @@
 FROM maven:3.5-jdk-9-slim
 WORKDIR /src
 COPY . /src
-RUN mvn package
+
+RUN apt-get update && apt-get install -y \
+  git \
+ && mvn package \
+ && rm -rf /var/lib/apt/lists/*
 
 FROM openjdk:9-jre-slim
 MAINTAINER Jose V. Trigueros <jose@gdragon.tech>
+
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="throw-voice" \
+      org.label-schema.description="A voice channel recording bot for Discord." \
+      org.label-schema.url="http://pawabot.site" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/guacamoledragon/throw-voice" \
+      org.label-schema.vendor="Guacamole Dragon, LLC" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.schema-version="1.0"
 
 WORKDIR /root/
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![Discord Bots](https://discordbots.org/api/widget/338897906524225538.png)](https://discordbots.org/bot/338897906524225538)  
 
+[![Waffle.io - Columns and their card count](https://badge.waffle.io/guacamoledragon/throw-voice.svg?columns=all)](https://waffle.io/guacamoledragon/throw-voice)  
 [![Build Status](https://travis-ci.org/guacamoledragon/throw-voice.svg?branch=master)](https://travis-ci.org/guacamoledragon/throw-voice)
 [![Coverage Status](https://coveralls.io/repos/github/guacamoledragon/throw-voice/badge.svg)](https://coveralls.io/github/guacamoledragon/throw-voice)
 [![Docker Pulls](https://img.shields.io/docker/pulls/gdragon/throw-voice.svg)](https://hub.docker.com/r/gdragon/throw-voice/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # throw-voice
 > A voice channel recording bot for Discord.
 
+[![Discord Bots](https://discordbots.org/api/widget/338897906524225538.png)](https://discordbots.org/bot/338897906524225538)  
+
 [![Build Status](https://travis-ci.org/guacamoledragon/throw-voice.svg?branch=master)](https://travis-ci.org/guacamoledragon/throw-voice)
 [![Coverage Status](https://coveralls.io/repos/github/guacamoledragon/throw-voice/badge.svg)](https://coveralls.io/github/guacamoledragon/throw-voice)
 [![Docker Pulls](https://img.shields.io/docker/pulls/gdragon/throw-voice.svg)](https://hub.docker.com/r/gdragon/throw-voice/)

--- a/build-docker.bat
+++ b/build-docker.bat
@@ -1,0 +1,7 @@
+@echo off
+for /F "usebackq tokens=1,2 delims==" %%i in (`wmic os get LocalDateTime /VALUE 2^>NUL`) do if '.%%i.'=='.LocalDateTime.' set ldt=%%j
+set BUILD_DATE=%ldt:~0,4%-%ldt:~4,2%-%ldt:~6,2%T%ldt:~8,2%:%ldt:~10,2%:%ldt:~12,6%Z
+
+for /F "delims=" %%a in ('git rev-parse --short HEAD') do @set VCS_REF=%%a
+
+docker build -t gdragon/throw-voice:%VERSION% --build-arg VCS_REF=%VCS_REF% --build-arg BUILD_DATE=%BUILD_DATE% --build-arg VERSION=%VERSION% .

--- a/src/main/java/tech/gdragon/DiscordBot.java
+++ b/src/main/java/tech/gdragon/DiscordBot.java
@@ -111,13 +111,11 @@ public class DiscordBot {
     }
 
     File dest;
+//    File raw;
     try {
-
-      if (new File("/var/www/html/").exists()) {
-        dest = new File("/var/www/html/" + getPJSaltString() + ".mp3");
-      } else {
-        dest = new File("recordings/" + getPJSaltString() + ".mp3");
-      }
+      String outputFile = "recordings/" + getPJSaltString();
+      dest = new File(outputFile + ".mp3");
+//      raw = new File(outputFile + ".pcm");
 
       byte[] voiceData;
       byte[] rawVoiceData;
@@ -126,6 +124,9 @@ public class DiscordBot {
         rawVoiceData = receiveListener.getUncompVoice(time);
         voiceData = encodePcmToMp3(rawVoiceData);
 
+        /*FileOutputStream rfos = new FileOutputStream(raw);
+        rfos.write(rawVoiceData);
+        rfos.close();*/
       } else {
         rawVoiceData = receiveListener.getUncompVoice((int) AudioReceiveListener.PCM_MINS * 60);
         voiceData = encodePcmToMp3(rawVoiceData);

--- a/src/main/java/tech/gdragon/DiscordBot.java
+++ b/src/main/java/tech/gdragon/DiscordBot.java
@@ -97,19 +97,19 @@ public class DiscordBot {
     writeToFile(guild, -1, tc);
   }
 
-  public static void writeToFile(Guild guild, int time, TextChannel tc) {
+  public static void writeToFile(Guild guild, int time, TextChannel textChannel) {
     Long defaultChannelId = Shim.INSTANCE.xaction(() -> {
       Settings settings = tech.gdragon.db.dao.Guild.Companion.findById(guild.getIdLong()).getSettings();
       return settings.getDefaultTextChannel();
     });
 
-    if (tc == null) {
-      tc = guild.getTextChannelById(defaultChannelId);
+    if (textChannel == null) {
+      textChannel = guild.getTextChannelById(defaultChannelId);
     }
 
-    AudioReceiveListener ah = (AudioReceiveListener) guild.getAudioManager().getReceiveHandler();
-    if (ah == null) {
-      BotUtils.sendMessage(tc, "I wasn't recording!");
+    AudioReceiveListener receiveListener = (AudioReceiveListener) guild.getAudioManager().getReceiveHandler();
+    if (receiveListener == null) {
+      BotUtils.sendMessage(textChannel, "I wasn't recording!");
       return;
     }
 
@@ -141,8 +141,8 @@ public class DiscordBot {
 
       // TODO: This checks the size of the file and does something else if the file is bigger than what Discord allows, this doesn't work.
       if (dest.length() / 1024 / 1024 < 8) {
-        final TextChannel channel = tc;
-        tc.sendFile(dest, null).queue(null, (Throwable) -> {
+        final TextChannel channel = textChannel;
+        textChannel.sendFile(dest, null).queue(null, (Throwable) -> {
           BotUtils.sendMessage(guild.getTextChannelById(defaultChannelId),
             "I don't have permissions to send files in " + channel.getName() + "!");
         });
@@ -165,8 +165,9 @@ public class DiscordBot {
 
         }).start();
 
-      } /*else {
-        BotUtils.sendMessage(tc, "http://DiscordEcho.com/" + dest.getName());
+      } else {
+        BotUtils.sendMessage(textChannel, "Could not upload to Discord, file too large: " + recordingSize + "MB.");
+        /*BotUtils.sendMessage(textChannel, "http://DiscordEcho.com/" + dest.getName());
 
         new Thread(() -> {
           try {
@@ -177,12 +178,12 @@ public class DiscordBot {
           dest.delete();
           System.out.println("\tDeleting file " + dest.getName() + "...");
 
-        }).start();
-      }*/
+        }).start();*/
+      }
 
     } catch (Exception e) {
       logger.error("Unknown error sending file", e);
-      BotUtils.sendMessage(tc, "Unknown error sending file");
+      BotUtils.sendMessage(textChannel, "Unknown error sending file");
     }
   }
 

--- a/src/main/java/tech/gdragon/listeners/AudioReceiveListener.java
+++ b/src/main/java/tech/gdragon/listeners/AudioReceiveListener.java
@@ -19,7 +19,7 @@ public class AudioReceiveListener implements AudioReceiveHandler {
 
   public static final double STARTING_MB = 0.5;
   public static final int CAP_MB = 8;
-  public static final double PCM_MINS = 2;
+  public static final double PCM_MINS = 8;
   private final double AFK_LIMIT = 2;
   public boolean canReceive = true;
   public double volume = 1.0;
@@ -155,7 +155,7 @@ public class AudioReceiveListener implements AudioReceiveHandler {
 
 
   public void wipeMemory() {
-    System.out.format("Wiped recording data in %s on %s", voiceChannel.getName(), voiceChannel.getGuild().getName());
+    logger.info("Wiped recording data in {} on {}", voiceChannel.getName(), voiceChannel.getGuild().getName());
     uncompIndex = 0;
     compIndex = 0;
 

--- a/src/main/java/tech/gdragon/listeners/AudioReceiveListener.java
+++ b/src/main/java/tech/gdragon/listeners/AudioReceiveListener.java
@@ -66,8 +66,9 @@ public class AudioReceiveListener implements AudioReceiveHandler {
         BotUtils.sendMessage(defaultTC, "No audio for 2 minutes, leaving from AFK detection...");
       }
 
-      voiceChannel.getGuild().getAudioManager().closeAudioConnection();
-      DiscordBot.killAudioHandlers(voiceChannel.getGuild());
+      // Can't close audio manager in the same thread in which the audio event is being handled: https://github.com/DV8FromTheWorld/JDA/issues/485#issuecomment-332559873
+      new Thread(() -> BotUtils.leaveVoiceChannel(voiceChannel)).start();
+
       return;
     }
 

--- a/src/main/java/tech/gdragon/listeners/AudioReceiveListener.java
+++ b/src/main/java/tech/gdragon/listeners/AudioReceiveListener.java
@@ -5,6 +5,8 @@ import net.dv8tion.jda.core.audio.CombinedAudio;
 import net.dv8tion.jda.core.audio.UserAudio;
 import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.entities.VoiceChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import tech.gdragon.BotUtils;
 import tech.gdragon.DiscordBot;
 import tech.gdragon.db.Shim;
@@ -13,8 +15,10 @@ import tech.gdragon.db.dao.Settings;
 import java.util.Arrays;
 
 public class AudioReceiveListener implements AudioReceiveHandler {
+  private Logger logger = LoggerFactory.getLogger(this.getClass());
+
   public static final double STARTING_MB = 0.5;
-  public static final int CAP_MB = 16;
+  public static final int CAP_MB = 8;
   public static final double PCM_MINS = 2;
   private final double AFK_LIMIT = 2;
   public boolean canReceive = true;
@@ -141,10 +145,9 @@ public class AudioReceiveListener implements AudioReceiveHandler {
 
         if (!overwriting) {
           overwriting = true;
-          System.out.format("Hit compressed storage cap in %s on %s", voiceChannel.getName(), voiceChannel.getGuild().getName());
+          logger.info("Hit compressed storage cap in {} on {}.", voiceChannel.getName(), voiceChannel.getGuild().getName());
         }
       }
-
 
       compVoiceData[compIndex++] = b;
     }

--- a/src/main/java/tech/gdragon/listeners/AudioReceiveListener.java
+++ b/src/main/java/tech/gdragon/listeners/AudioReceiveListener.java
@@ -167,11 +167,12 @@ public class AudioReceiveListener implements AudioReceiveHandler {
   public byte[] getUncompVoice(int time) {
     canReceive = false;
 
-    if (time > PCM_MINS * 60 * 2) {     //2 mins
+    if (time > PCM_MINS * 60 * 2) {
       time = (int) (PCM_MINS * 60 * 2);
     }
+
     int requestSize = 3840 * 50 * time;
-    byte[] voiceData = new byte[requestSize];
+    byte[] voiceData = new byte[(requestSize < uncompIndex) ? requestSize : uncompIndex];
 
     for (int i = 0; i < voiceData.length; i++) {
       if (uncompIndex + i < voiceData.length) {


### PR DESCRIPTION
This MR fixes the following issues:

- Closing the audio connection would cause a ThreadInterruptedException
  - Source: https://github.com/DV8FromTheWorld/JDA/issues/485#issuecomment-332559873
- If recording was larger than 8MB, the upload would never happen (or say anything). For now, limiting recordings to 8 minutes, which is about the ~7mb which puts us below the Discord upload limit.

Some non-fixes:

- Dockerfile now includes labels for better metadata that MicroBadger can use
- Added `pawa` badge to README.md