### PR TITLE
Re-instate `clip` command

### DIFF
--- a/src/main/java/tech/gdragon/DiscordBot.java
+++ b/src/main/java/tech/gdragon/DiscordBot.java
@@ -6,7 +6,7 @@ import net.dv8tion.jda.core.JDABuilder;
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.exceptions.RateLimitedException;
 import tech.gdragon.commands.CommandHandler;
-import tech.gdragon.commands.audio.ClipCommand;
+import tech.gdragon.commands.audio.Clip;
 import tech.gdragon.commands.audio.EchoCommand;
 import tech.gdragon.commands.audio.MessageInABottleCommand;
 import tech.gdragon.commands.audio.Save;
@@ -33,7 +33,7 @@ public class DiscordBot {
       CommandHandler.commands.put("leave", new Leave());
 
       // Register audio commands
-      CommandHandler.commands.put("clip", new ClipCommand());
+      CommandHandler.commands.put("clip", new Clip());
       CommandHandler.commands.put("echo", new EchoCommand());
       CommandHandler.commands.put("miab", new MessageInABottleCommand());
       CommandHandler.commands.put("save", new Save());

--- a/src/main/kotlin/tech/gdragon/AppQueueTape.kt
+++ b/src/main/kotlin/tech/gdragon/AppQueueTape.kt
@@ -1,2 +1,0 @@
-package tech.gdragon
-

--- a/src/main/kotlin/tech/gdragon/AppQueueTape.kt
+++ b/src/main/kotlin/tech/gdragon/AppQueueTape.kt
@@ -1,0 +1,2 @@
+package tech.gdragon
+

--- a/src/main/kotlin/tech/gdragon/commands/audio/Clip.kt
+++ b/src/main/kotlin/tech/gdragon/commands/audio/Clip.kt
@@ -1,0 +1,57 @@
+package tech.gdragon.commands.audio
+
+import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
+import org.jetbrains.exposed.sql.transactions.transaction
+import tech.gdragon.BotUtils
+import tech.gdragon.commands.Command
+import tech.gdragon.db.dao.Guild
+import tech.gdragon.listener.CombinedAudioRecorderHandler
+
+class Clip : Command {
+  override fun action(args: Array<out String>, event: GuildMessageReceivedEvent) {
+    val prefix = transaction {
+      val guild = Guild.findById(event.guild.idLong)
+      guild?.settings?.prefix ?: "!"
+    }
+
+    require(args.size in 1..2) {
+      BotUtils.sendMessage(event.channel, usage(prefix))
+    }
+
+    val message =
+      if (event.guild.audioManager.connectedChannel == null) {
+        "I wasn't recording!"
+      } else {
+        val voiceChannel = event.guild.audioManager.connectedChannel.name
+        val audioReceiveHandler = event.guild.audioManager.receiveHandler as CombinedAudioRecorderHandler
+
+        try {
+          val seconds = args.first().toLong()
+
+          if (args.size == 1) {
+            audioReceiveHandler.saveClip(seconds, voiceChannel, event.channel)
+            ""
+          } else {
+            val channelName = if (args[1].startsWith("#")) args[1].substring(1) else args[1]
+            val channels = event.guild.getTextChannelsByName(channelName, true)
+
+            if (channels.isEmpty()) {
+              "Cannot find $channelName."
+            } else {
+              channels.forEach { audioReceiveHandler.saveClip(seconds, voiceChannel, event.channel) }
+              ""
+            }
+          }
+        } catch (e: NumberFormatException) {
+          usage(prefix)
+        }
+      }
+
+    if (message.isNotBlank())
+      BotUtils.sendMessage(event.channel, message)
+  }
+
+  override fun usage(prefix: String): String = "${prefix}clip [seconds] | ${prefix}clip [seconds] [text channel output]"
+
+  override fun description(): String = "Saves a clip of the specified length (seconds) and outputs it in the current or specified text channel."
+}

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -31,7 +31,7 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
     private const val BUFFER_TIMEOUT = 200L                 // 200 milliseconds
     private const val BUFFER_MAX_COUNT = 8
     private const val BITRATE = 128                         // 128 kpbs
-    private const val BYTES_PER_SECOND = 16_000             // 128 kbps == 16000 bytes per second
+    private const val BYTES_PER_SECOND = 16_000L            // 128 kbps == 16000 bytes per second
   }
 
   private val logger = LoggerFactory.getLogger(this.javaClass)
@@ -142,6 +142,7 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
 
     logger.info("Saving audio file '{}' from {} on {} of size {} MB.",
       recording.name, voiceChannel?.name, voiceChannel?.guild?.name, recordingSizeInMB)
+    logger.debug("Recording size in bytes: {}", recordingSize)
 
     uploadRecording(recording, recordingSizeInMB, voiceChannel?.name, voiceChannel?.guild?.name, textChannel)
 

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -138,12 +138,12 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
       }
     }
 
-    val recordingSize = recording.length().toDouble() / 1024 / 1024
+    val recordingSizeInMB = recording.length().toDouble() / 1024 / 1024
 
     logger.info("Saving audio file '{}' from {} on {} of size {} MB.",
-      recording.name, voiceChannel?.name, voiceChannel?.guild?.name, recordingSize)
+      recording.name, voiceChannel?.name, voiceChannel?.guild?.name, recordingSizeInMB)
 
-    uploadRecording(recording, recordingSize, voiceChannel?.name, voiceChannel?.guild?.name, textChannel)
+    uploadRecording(recording, recordingSizeInMB, voiceChannel?.name, voiceChannel?.guild?.name, textChannel)
 
     // Resume recording
     subscription = createRecording()

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -148,7 +148,7 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
     subscription = createRecording()
   }
 
-  fun saveClip(seconds: Long) {
+  fun saveClip(seconds: Long, voiceChannel: String?, channel: TextChannel?) {
     canReceive = false
     val byteRate = BITRATE / 8
 
@@ -165,10 +165,12 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
       val recordingSize = recording.length().toDouble() / 1024 / 1024
 
       logger.info("Saving audio file '{}' from {} on {} of size {} MB.",
-          recording.name, "", "", recordingSize)
+          recording.name, voiceChannel, channel?.guild?.name, recordingSize)
 
-      uploadRecording(recording, recordingSize, "", "", null)
+      uploadRecording(recording, recordingSize, voiceChannel, channel?.guild?.name, channel)
     }
+
+    canReceive = true
   }
 
   private fun uploadRecording(recording: File, recordingSize: Double, voiceChannelName: String?, guildName: String?, channel: TextChannel?) {
@@ -195,7 +197,7 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
         logger.info("Deleting file {}...", recording.name)
 
         if (isDeleteSuccess)
-          logger.info("Successfully deleted file {}. ", recording.name)
+          logger.info("Successfully deleted file {}.", recording.name)
         else
           logger.error("Could not delete file {}.", recording.name)
       }

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -31,6 +31,7 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
     private const val BUFFER_TIMEOUT = 200L                 // 200 milliseconds
     private const val BUFFER_MAX_COUNT = 8
     private const val BITRATE = 128                         // 128 kpbs
+    private const val BYTES_PER_SECOND = 16_000             // 128 kbps == 16000 bytes per second
   }
 
   private val logger = LoggerFactory.getLogger(this.javaClass)


### PR DESCRIPTION
In the previous (#12) MR, I decided to remove the `clip` and `echo` commands not knowing that they'd still be in use. Since recording and encoding is now very different it wasn't a trivial change to bring the `clip` command back. 

The way the clip command no works is not super awesome, but it'll work for now:

- Create a copy of the `QueueFile` which contains current recording
- Drop entries in the queue until the size is close enough to the requested size in seconds

This leverages the fact that the MP3 encoder is encoding at 128 kbps, so that ends up being 16,000 bytes per second. So we can use the power of math to figure out how much that is.

This isn't the best solution because you _have_ to iterate through most of the recording, right now it's not too bad cause at most a recording will be 8MB, but once that limit is removed a different solution will have to be implemented (if and only if performance deteriorates).

Closes #14 