### PR TITLE
Enable foreign key support

### DIFF
--- a/src/main/kotlin/tech/gdragon/db/Shim.kt
+++ b/src/main/kotlin/tech/gdragon/db/Shim.kt
@@ -15,7 +15,10 @@ import java.sql.Connection
  */
 object Shim {
   fun initializeDatabase(database: String) {
-    Database.connect("jdbc:sqlite:$database", driver = "org.sqlite.JDBC")
+    Database.connect("jdbc:sqlite:$database", driver = "org.sqlite.JDBC", setupConnection = {
+      val statement = it.createStatement()
+      statement.executeUpdate("PRAGMA foreign_keys = ON")
+    })
     TransactionManager.manager.defaultIsolationLevel = Connection.TRANSACTION_READ_UNCOMMITTED
 
     transaction {

--- a/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
+++ b/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
@@ -2,6 +2,7 @@ package tech.gdragon.db.dao
 
 import org.jetbrains.exposed.dao.*
 import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.exposedLogger
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.db.table.Tables.Aliases
 import tech.gdragon.db.table.Tables.Channels
@@ -55,7 +56,7 @@ class Guild(id: EntityID<Long>) : LongEntity(id) {
         commit()
 
         Alias.createDefaultAliases(settings)
-
+        exposedLogger.info("Creating database entry for: ${settings.guild.name}")
         settings.guild
       }
     }

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -197,7 +197,7 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
 
       val message = MessageBuilder().also {
         it.append("Unfortunately, current recordings are limited to the last 8MB recorded. Increasing limit in upcoming releases.")
-        it.append("Recording for $voiceChannelName in $guildName.")
+        it.append("\nRecording for $voiceChannelName in $guildName.")
       }
 
       channel


### PR DESCRIPTION
If the PRAGMA `foreign_keys` isn't ON, then SQLite isn't able to do cascading deletes which is absolutely necessary when removing a Guild.

The bug that surfaced this was when a user would kick the bot, then added it again. This would cause the entry in the Guild table to get deleted but none of the other related tables would get deleted, so when the bot gets re-added it gets confused as it sees that say for example, the Settings entry already exists. Super cryptic error.