### PR TITLE
Missing Channel

### DIFF
--- a/src/main/kotlin/tech/gdragon/commands/misc/Help.kt
+++ b/src/main/kotlin/tech/gdragon/commands/misc/Help.kt
@@ -23,7 +23,7 @@ class Help : Command {
       val embed = EmbedBuilder().apply {
         setAuthor("pawa", "http://pawabot.site", event.jda.selfUser.avatarUrl)
         setColor(Color.decode("#596800"))
-        setTitle("Currently in beta, being actively developed and tested. Expect bugs.")
+        setTitle("Currently in beta, being actively developed and tested. Expect bugs. All settings get cleared on every beta release")
         setDescription("**pawa** is an implementation of _throw-voice_, check out [GitHub](https://github.com/guacamoledragon/throw-voice) for updates!")
         setThumbnail(event.jda.selfUser.avatarUrl)
         setFooter("Replace brackets [] with item specified. Vertical bar | means 'or', either side of bar is valid choice.", null)

--- a/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
+++ b/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
@@ -29,7 +29,25 @@ class Alias(id: EntityID<Int>) : IntEntity(id) {
 }
 
 class Channel(id: EntityID<Long>) : LongEntity(id) {
-  companion object : LongEntityClass<Channel>(Channels)
+  companion object : LongEntityClass<Channel>(Channels) {
+    fun findOrCreate(id: Long, name: String, guildId: Long, guildName: String): Iterable<Channel> = transaction {
+      val guild = Guild.findOrCreate(guildId, guildName)
+      val channels = Channel.find { (Channels.settings eq guild.settings.id) and (Channels.id eq id) }
+
+      if (channels.empty()) {
+        val newChannel = Channel.new(id) {
+          this.name = name
+          this.settings = guild.settings
+        }
+
+        commit()
+
+        listOf(newChannel)
+      } else {
+        channels
+      }
+    }
+  }
 
   var name by Channels.name
   var autoJoin by Channels.autoJoin


### PR DESCRIPTION
The `autojoin` and `autoleave` commands look for an entry in the database to determine what they should do. The problem was that if there was no existing Channel row the command would not do anything, which is great in terms of not crashing, but bad in terms of functionality.

A `findOrCreate` function got added to the Channel DAO object so that it can be used and create a Channel row if none exists.