### PR TITLE
Handle Invalid Commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ buildNumber.properties
 #
 *.iml
 .idea/*
-!.idea/runConfigurations/
 
 .env*
 settings.json

--- a/src/main/kotlin/tech/gdragon/commands/Command.kt
+++ b/src/main/kotlin/tech/gdragon/commands/Command.kt
@@ -7,10 +7,13 @@ import tech.gdragon.db.dao.Guild
 import java.util.*
 
 interface Command {
+  @Throws(InvalidCommand::class)
   fun action(args: Array<String>, event: GuildMessageReceivedEvent)
   fun usage(prefix: String): String
   fun description(): String
 }
+
+data class InvalidCommand(val usage: (String) -> String, val reason: String) : Throwable()
 
 object CommandHandler {
   @JvmField
@@ -19,6 +22,7 @@ object CommandHandler {
 
   // TODO this guy needs to throw exceptions all the way to EventListener
   @JvmStatic
+  @Throws(InvalidCommand::class)
   fun handleCommand(event: GuildMessageReceivedEvent, commandContainer: CommandContainer): Boolean {
     return transaction {
       var isSuccess = false

--- a/src/main/kotlin/tech/gdragon/commands/Command.kt
+++ b/src/main/kotlin/tech/gdragon/commands/Command.kt
@@ -20,7 +20,6 @@ object CommandHandler {
   val parser = CommandParser()
   var commands = HashMap<String, Command>()
 
-  // TODO this guy needs to throw exceptions all the way to EventListener
   @JvmStatic
   @Throws(InvalidCommand::class)
   fun handleCommand(event: GuildMessageReceivedEvent, commandContainer: CommandContainer): Boolean {

--- a/src/main/kotlin/tech/gdragon/commands/audio/Clip.kt
+++ b/src/main/kotlin/tech/gdragon/commands/audio/Clip.kt
@@ -4,18 +4,14 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.listener.CombinedAudioRecorderHandler
 
 class Clip : Command {
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
-    val prefix = transaction {
-      val guild = Guild.findById(event.guild.idLong)
-      guild?.settings?.prefix ?: "!"
-    }
-
     require(args.size in 1..2) {
-      BotUtils.sendMessage(event.channel, usage(prefix))
+      throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
     }
 
     val message =
@@ -43,7 +39,7 @@ class Clip : Command {
             }
           }
         } catch (e: NumberFormatException) {
-          usage(prefix)
+          throw InvalidCommand(::usage, "Could not parse arguments: ${e.message}")
         }
       }
 

--- a/src/main/kotlin/tech/gdragon/commands/audio/Save.kt
+++ b/src/main/kotlin/tech/gdragon/commands/audio/Save.kt
@@ -4,17 +4,14 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.listener.CombinedAudioRecorderHandler
 
 class Save : Command {
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
     require(args.size in 0..1) {
-      transaction {
-        val guild = Guild.findById(event.guild.idLong)
-        val prefix = guild?.settings?.prefix ?: "!"
-        BotUtils.sendMessage(event.channel, usage(prefix))
-      }
+      throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
     }
 
     val message =

--- a/src/main/kotlin/tech/gdragon/commands/misc/Help.kt
+++ b/src/main/kotlin/tech/gdragon/commands/misc/Help.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
 import tech.gdragon.commands.CommandHandler
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
 import java.awt.Color
 
@@ -16,7 +17,7 @@ class Help : Command {
       val prefix = guild?.settings?.prefix ?: "!"
 
       require(args.isEmpty()) {
-        BotUtils.sendMessage(event.channel, usage(prefix))
+        throw InvalidCommand(::usage, "Empty arguments")
       }
 
       val disclaimer = """|**Depending on where you live, it _may_ be illegal to record without everyone's consent. Please

--- a/src/main/kotlin/tech/gdragon/commands/misc/Help.kt
+++ b/src/main/kotlin/tech/gdragon/commands/misc/Help.kt
@@ -19,12 +19,20 @@ class Help : Command {
         BotUtils.sendMessage(event.channel, usage(prefix))
       }
 
+      val disclaimer = """|**Depending on where you live, it _may_ be illegal to record without everyone's consent. Please
+                          |check your local laws.**
+                          |
+                          |https://en.wikipedia.org/wiki/Telephone_recording_laws
+                          |_This is not legal advice._
+                          |""".trimMargin()
+
       // TODO must be configurable
       val embed = EmbedBuilder().apply {
-        setAuthor("pawa", "http://pawabot.site", event.jda.selfUser.avatarUrl)
+        setAuthor("pawa", "https://www.pawabot.site", event.jda.selfUser.avatarUrl)
         setColor(Color.decode("#596800"))
         setTitle("Currently in beta, being actively developed and tested. Expect bugs. All settings get cleared on every beta release")
-        setDescription("**pawa** is an implementation of _throw-voice_, check out [GitHub](https://github.com/guacamoledragon/throw-voice) for updates!")
+        setDescription("**pawa** is an implementation of _throw-voice_, check out [GitHub](https://github.com/guacamoledragon/throw-voice) for updates!\n\n")
+        appendDescription(disclaimer)
         setThumbnail(event.jda.selfUser.avatarUrl)
         setFooter("Replace brackets [] with item specified. Vertical bar | means 'or', either side of bar is valid choice.", null)
         addBlankField(false)

--- a/src/main/kotlin/tech/gdragon/commands/misc/Join.kt
+++ b/src/main/kotlin/tech/gdragon/commands/misc/Join.kt
@@ -4,30 +4,30 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.listener.CombinedAudioRecorderHandler
 
 class Join : Command {
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
+    require(args.isEmpty()) {
+      throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
+    }
+
     transaction {
       val guild = Guild.findById(event.guild.idLong)
-      val prefix = guild?.settings?.prefix ?: "!"
-
-      require(args.isEmpty()) {
-        BotUtils.sendMessage(event.channel, usage(prefix))
-      }
 
       val voiceChannel = event.member.voiceState.channel
       val message =
-        if(voiceChannel == null) {
+        if (voiceChannel == null) {
           ":no_entry_sign: _Please join a voice channel before using this command._"
         } else {
           val connectedChannel = event.guild.audioManager.connectedChannel
-          if(connectedChannel != null && connectedChannel.members.contains(event.member)) {
+          if (connectedChannel != null && connectedChannel.members.contains(event.member)) {
             ":no_entry_sign: _I am already in **<#${connectedChannel.id}>**._"
           } else {
 
-            if(event.guild.audioManager.isConnected) {
+            if (event.guild.audioManager.isConnected) {
               guild?.settings?.let {
                 if (it.autoSave) {
                   val audioReceiveHandler = event.guild.audioManager.receiveHandler as CombinedAudioRecorderHandler

--- a/src/main/kotlin/tech/gdragon/commands/misc/Leave.kt
+++ b/src/main/kotlin/tech/gdragon/commands/misc/Leave.kt
@@ -29,9 +29,9 @@ class Leave : Command {
           }
 
           BotUtils.leaveVoiceChannel(voiceChannel)
-          "Leaving ${voiceChannel.name}"
+          ":wave: _Leaving **<#${voiceChannel.id}>**_"
         } else {
-          "I am not in a channel!"
+          ":no_entry_sign: _I am not in a channel_"
         }
 
       BotUtils.sendMessage(event.channel, message)

--- a/src/main/kotlin/tech/gdragon/commands/misc/Leave.kt
+++ b/src/main/kotlin/tech/gdragon/commands/misc/Leave.kt
@@ -4,18 +4,18 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.listener.CombinedAudioRecorderHandler
 
 class Leave : Command {
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
+    require(args.isEmpty()) {
+      throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
+    }
+
     transaction {
       val guild = Guild.findById(event.guild.idLong)
-      val prefix = guild?.settings?.prefix ?: "!"
-
-      require(args.isEmpty()) {
-        BotUtils.sendMessage(event.channel, usage(prefix))
-      }
 
       val message =
         if (event.guild.audioManager.isConnected) {

--- a/src/main/kotlin/tech/gdragon/commands/settings/Alerts.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/Alerts.kt
@@ -4,42 +4,46 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.db.dao.User
 import tech.gdragon.db.table.Tables.Users
-import java.util.function.Consumer
 
 class Alerts : Command {
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
     val guildId = event.guild.idLong
-    val prefix = transaction { Guild.findById(guildId)!!.settings.prefix }
     val channel = event.channel
-
-    var message = usage(prefix)
 
     if (args.size == 1) {
       val author = event.author
 
       transaction {
         val userList = User.find { Users.id eq author.idLong }
-        when (args[0]) {
-          "off" -> {
-            val guild = Guild.findById(guildId)
-            if (userList.empty()) {
-              User.new(author.idLong) {
-                name = author.name
-                settings = guild!!.settings
+        val message =
+          when (args.first()) {
+            "off" -> {
+              val guild = Guild.findById(guildId)
+              if (userList.empty()) {
+                User.new(author.idLong) {
+                  name = author.name
+                  settings = guild!!.settings
+                }
               }
+              ":bangbang: _Alerts now **off**_"
             }
-            message = "Alerts now off, message `${prefix}alerts on` to re-enable at any time"
+            "on" -> {
+              userList.forEach { it.delete() }
+              ":bangbang: _Alerts now **on**_"
+            }
+            else -> {
+              throw InvalidCommand(::usage, "Invalid argument: ${args.first()}")
+            }
           }
-          "on" -> {
-            userList.forEach{ it.delete() }
-            message = "Alerts now on, message `${prefix}alerts off` to disable at any time"
-          }
-        }
+
+        BotUtils.sendMessage(channel, message)
       }
-      BotUtils.sendMessage(channel, message)
+    } else {
+      throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
     }
   }
 

--- a/src/main/kotlin/tech/gdragon/commands/settings/Alias.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/Alias.kt
@@ -5,15 +5,14 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
 import tech.gdragon.commands.CommandHandler
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Alias
 import tech.gdragon.db.dao.Guild
 
 class Alias : Command {
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
-    // Argument count must be two
     require(args.size == 2) {
-      val prefix = transaction { Guild.findById(event.guild.idLong)!!.settings.prefix }
-      BotUtils.sendMessage(event.channel, usage(prefix))
+      throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
     }
 
     val channel = event.channel

--- a/src/main/kotlin/tech/gdragon/commands/settings/AutoJoin.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/AutoJoin.kt
@@ -1,21 +1,20 @@
 package tech.gdragon.commands.settings
 
-import mu.KotlinLogging
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Channel
-import tech.gdragon.db.dao.Guild
 import net.dv8tion.jda.core.entities.Channel as DiscordChannel
 
 class AutoJoin : Command {
-  private val commandLogger = KotlinLogging.logger {}
-
   private fun updateChannelAutoJoin(channel: DiscordChannel, autoJoin: Int?) {
-    Channel
-      .findOrCreate(channel.idLong, channel.name, channel.guild.idLong, channel.guild.name)
-      .forEach { it.autoJoin = autoJoin }
+    transaction {
+      Channel
+        .findOrCreate(channel.idLong, channel.name, channel.guild.idLong, channel.guild.name)
+        .forEach { it.autoJoin = autoJoin }
+    }
   }
 
   /**
@@ -23,64 +22,57 @@ class AutoJoin : Command {
    * channel is disabled.
    */
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
-    transaction {
-      val guildId = event.guild.idLong
-      val prefix = Guild.findById(guildId)?.settings!!.prefix
+    require(args.size >= 2) {
+      throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
+    }
 
-      require(args.size >= 2) {
-        BotUtils.sendMessage(event.channel, usage(prefix))
-      }
+    val message: String =
+      try {
+        val channelName = args.dropLast(1).joinToString(" ")
+        val number: Int? = when (args.last()) {
+          "off" -> null
+          "0" -> null
+          else -> {
+            val lastArg = args.last().toInt()
 
-      val message: String =
-        try {
-          val channelName = args.dropLast(1).joinToString(" ")
-          val number: Int? = when (args.last()) {
-            "off" -> null
-            "0" -> null
-            else -> {
-              val lastArg = args.last().toInt()
-
-              if (lastArg < 0)
-                throw IllegalArgumentException("Number must be positive!")
-              else
-                lastArg
-            }
+            if (lastArg < 0)
+              throw IllegalArgumentException("Number must be positive!")
+            else
+              lastArg
           }
+        }
 
-          if (channelName == "all") {
-            val channels = event.guild.voiceChannels
+        if (channelName == "all") {
+          val channels = event.guild.voiceChannels
+          channels.forEach { updateChannelAutoJoin(it, number) }
+
+          if (number != null) {
+            "Will now automatically join any voice channel with $number or more people."
+          } else {
+            "Will no longer automatically join any channel."
+          }
+        } else {
+          val channels = event.guild.getVoiceChannelsByName(channelName, true)
+
+          if (channels.isEmpty()) {
+            "Cannot find voice channel $channelName."
+          } else {
             channels.forEach { updateChannelAutoJoin(it, number) }
 
             if (number != null) {
-              "Will now automatically join any voice channel with $number or more people."
+              "Will now automatically join '$channelName' when there are $number or more people."
             } else {
-              "Will no longer automatically join any channel."
-            }
-          } else {
-            val channels = event.guild.getVoiceChannelsByName(channelName, true)
-
-            if (channels.isEmpty()) {
-              "Cannot find voice channel $channelName."
-            } else {
-              channels.forEach { updateChannelAutoJoin(it, number) }
-
-              if (number != null) {
-                "Will now automatically join '$channelName' when there are $number or more people."
-              } else {
-                "Will no longer automatically join '$channelName'."
-              }
+              "Will no longer automatically join '$channelName'."
             }
           }
-        } catch (e: NumberFormatException) {
-          commandLogger.error(e) { "${event.guild.name}: Could not parse number argument." }
-          usage(prefix)
-        } catch (e: IllegalArgumentException) {
-          commandLogger.error(e) { "${event.guild.name}: Number must be positive." }
-          e.message
-        } ?: usage(prefix)
+        }
+      } catch (e: NumberFormatException) {
+        throw InvalidCommand(::usage, "Could not parse number argument: ${e.message}")
+      } catch (e: IllegalArgumentException) {
+        throw InvalidCommand(::usage, "Number must be positive: ${e.message}")
+      }
 
-      BotUtils.sendMessage(event.channel, message)
-    }
+    BotUtils.sendMessage(event.channel, message)
   }
 
   override fun usage(prefix: String): String = "${prefix}autojoin [Voice Channel name | 'all'] [number | 'off']"

--- a/src/main/kotlin/tech/gdragon/commands/settings/AutoLeave.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/AutoLeave.kt
@@ -1,66 +1,57 @@
 package tech.gdragon.commands.settings
 
-import mu.KotlinLogging
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Channel
-import tech.gdragon.db.dao.Guild
 import net.dv8tion.jda.core.entities.Channel as DiscordChannel
 
 class AutoLeave : Command {
-  private val commandLogger = KotlinLogging.logger {}
-
   private fun updateChannelAutoLeave(channel: DiscordChannel, autoLeave: Int) {
-    Channel
-      .findOrCreate(channel.idLong, channel.name, channel.guild.idLong, channel.guild.name)
-      .forEach { it.autoLeave = autoLeave }
+    transaction {
+      Channel
+        .findOrCreate(channel.idLong, channel.name, channel.guild.idLong, channel.guild.name)
+        .forEach { it.autoLeave = autoLeave }
+    }
   }
 
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
-    transaction {
-      val guildId = event.guild.idLong
-      val guild = Guild.findById(guildId)
-      val prefix = guild?.settings?.prefix ?: "!"
+    require(args.size >= 2) {
+      throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
+    }
 
-      require(args.size >= 2) {
-        BotUtils.sendMessage(event.channel, usage(prefix))
+    val message =
+      try {
+        val channelName = args.dropLast(1).joinToString(" ")
+        val number: Int = args.last().toInt()
+
+        check(number > 0) {
+          "Number must be positive!"
+        }
+
+        if (channelName == "all") {
+          val channels = event.guild.voiceChannels
+          channels.forEach { updateChannelAutoLeave(it, number) }
+          "Will now automatically leave any voice channel with $number or less people."
+        } else {
+          val channels = event.guild.getVoiceChannelsByName(channelName, true)
+
+          if (channels.isEmpty()) {
+            "Cannot find voice channel $channelName."
+          } else {
+            channels.forEach { updateChannelAutoLeave(it, number) }
+            "Will now automatically leave '$channelName' when there are $number or less people."
+          }
+        }
+      } catch (e: NumberFormatException) {
+        throw InvalidCommand(::usage, "Could not parse number argument: ${e.message}")
+      } catch (e: IllegalArgumentException) {
+        throw InvalidCommand(::usage, "Number must be positive: ${e.message}")
       }
 
-      val message =
-        try {
-          val channelName = args.dropLast(1).joinToString(" ")
-          val number: Int = args.last().toInt()
-
-          check(number > 0) {
-            "Number must be positive!"
-          }
-
-          if (channelName == "all") {
-            val channels = event.guild.voiceChannels
-            channels.forEach { updateChannelAutoLeave(it, number) }
-            "Will now automatically leave any voice channel with $number or less people."
-          } else {
-            val channels = event.guild.getVoiceChannelsByName(channelName, true)
-
-            if (channels.isEmpty()) {
-              "Cannot find voice channel $channelName."
-            } else {
-              channels.forEach { updateChannelAutoLeave(it, number) }
-              "Will now automatically leave '$channelName' when there are $number or less people."
-            }
-          }
-        } catch (e: NumberFormatException) {
-          commandLogger.error(e) { "${event.guild.name}: Could not parse number argument." }
-          usage(prefix)
-        } catch (e: IllegalStateException) {
-          commandLogger.error(e) { "${event.guild.name}: Number must be positive." }
-          e.message
-        } ?: usage(prefix)
-
-      BotUtils.sendMessage(event.channel, message)
-    }
+    BotUtils.sendMessage(event.channel, message)
   }
 
   override fun usage(prefix: String): String = "${prefix}autoleave [Voice Channel name | 'all'] [number]"

--- a/src/main/kotlin/tech/gdragon/commands/settings/AutoSave.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/AutoSave.kt
@@ -4,17 +4,18 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
 
 class AutoSave : Command {
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
-    transaction {
-      val guild = Guild.findById(event.guild.idLong)
-      val prefix = guild?.settings?.prefix ?: "!"
 
       require(args.isEmpty()) {
-        BotUtils.sendMessage(event.channel, usage(prefix))
+        throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
       }
+
+    transaction {
+      val guild = Guild.findById(event.guild.idLong)
 
       val message =
         guild?.settings?.let {

--- a/src/main/kotlin/tech/gdragon/commands/settings/Prefix.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/Prefix.kt
@@ -4,18 +4,17 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
 
 class Prefix : Command {
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
+    require(args.size == 1) {
+      throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
+    }
+
     transaction {
       val guild = Guild.findById(event.guild.idLong)
-      val prefix = guild?.settings?.prefix ?: "!"
-
-      require(args.size == 1) {
-        BotUtils.sendMessage(event.channel, usage(prefix))
-      }
-
       val newPrefix = args.first()
 
       val message =

--- a/src/main/kotlin/tech/gdragon/commands/settings/RemoveAlias.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/RemoveAlias.kt
@@ -4,17 +4,18 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
 
 class RemoveAlias : Command {
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
+    require(args.size == 1) {
+      throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
+    }
+
     transaction {
       val guild = Guild.findById(event.guild.idLong)
-      val prefix = guild?.settings?.prefix ?: "!"
 
-      require(args.size == 1) {
-        BotUtils.sendMessage(event.channel, usage(prefix))
-      }
 
       val alias = args.first().toLowerCase()
 

--- a/src/main/kotlin/tech/gdragon/commands/settings/SaveLocation.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/SaveLocation.kt
@@ -4,17 +4,17 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
 
 class SaveLocation : Command {
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
+    require(args.size in 0..1) {
+      throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
+    }
+
     transaction {
       val guild = Guild.findById(event.guild.idLong)
-      val prefix = guild?.settings?.prefix ?: "!"
-
-      require(args.size in 0..1) {
-        BotUtils.sendMessage(event.channel, usage(prefix))
-      }
 
       val message =
         guild?.settings?.let {
@@ -23,7 +23,7 @@ class SaveLocation : Command {
 
             "Now defaulting to the ${event.channel.name} text channel."
           } else {
-            val channelName = if(args.first().startsWith("#")) args.first().substring(1) else args.first()
+            val channelName = if (args.first().startsWith("#")) args.first().substring(1) else args.first()
 
             val channels = event.guild.getTextChannelsByName(channelName, true)
 

--- a/src/main/kotlin/tech/gdragon/commands/settings/Volume.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/Volume.kt
@@ -4,18 +4,19 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
 import java.math.BigDecimal
 
 class Volume : Command {
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
+    require(args.size == 1) {
+      throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
+    }
+
     transaction {
       val guild = Guild.findById(event.guild.idLong)
       val prefix = guild?.settings?.prefix ?: "!"
-
-      require(args.size == 1) {
-        BotUtils.sendMessage(event.channel, usage(prefix))
-      }
 
       val message: String =
         try {

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -208,7 +208,6 @@ class EventListener : ListenerAdapter() {
     }
   }
 
-  // TODO continue work here!
   override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {
     if (event.member == null || event.member.user == null || event.member.user.isBot)
       return
@@ -229,8 +228,8 @@ class EventListener : ListenerAdapter() {
         CommandHandler.handleCommand(event, CommandHandler.parser.parse(prefix, rawContent.toLowerCase()))
       } catch (e: InvalidCommand) {
         val channel = event.channel
-        BotUtils.sendMessage(channel, e.usage(prefix))
-        logger.error { "${event.guild.name}#${channel.name}: [$rawContent] ${e.reason}" }
+        BotUtils.sendMessage(channel, ":no_entry_sign: _Usage: `${e.usage(prefix)}`_")
+        logger.warn { "${event.guild.name}#${channel.name}: [$rawContent] ${e.reason}" }
       }
     }
   }

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -2,8 +2,6 @@ package tech.gdragon.listener
 
 import mu.KotlinLogging
 import net.dv8tion.jda.core.entities.Game
-import net.dv8tion.jda.core.events.Event
-import net.dv8tion.jda.core.entities.Guild as DiscordGuild
 import net.dv8tion.jda.core.events.ReadyEvent
 import net.dv8tion.jda.core.events.guild.GuildJoinEvent
 import net.dv8tion.jda.core.events.guild.GuildLeaveEvent
@@ -22,6 +20,7 @@ import tech.gdragon.db.dao.User
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Paths
+import net.dv8tion.jda.core.entities.Guild as DiscordGuild
 
 class EventListener : ListenerAdapter() {
 
@@ -231,7 +230,7 @@ class EventListener : ListenerAdapter() {
       } catch (e: InvalidCommand) {
         val channel = event.channel
         BotUtils.sendMessage(channel, e.usage(prefix))
-        logger.error { "${event.guild.name}#${channel.name}: ${e.reason}" }
+        logger.error { "${event.guild.name}#${channel.name}: [$rawContent] ${e.reason}" }
       }
     }
   }

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -227,8 +227,6 @@ class EventListener : ListenerAdapter() {
     if (rawContent.startsWith(prefix)) {
       // TODO: handle any CommandHandler exceptions here
       CommandHandler.handleCommand(event, CommandHandler.parser.parse(prefix, rawContent.toLowerCase()))
-    } else if (rawContent == "!help") { // force help to always work with "!" prefix
-      CommandHandler.handleCommand(event, CommandHandler.parser.parse(prefix, prefix + "help"))
     }
   }
 

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -16,6 +16,7 @@ import net.dv8tion.jda.core.hooks.ListenerAdapter
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.CommandHandler
+import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.db.dao.User
 import java.io.IOException
@@ -225,8 +226,13 @@ class EventListener : ListenerAdapter() {
 
     val rawContent = event.message.contentDisplay
     if (rawContent.startsWith(prefix)) {
-      // TODO: handle any CommandHandler exceptions here
-      CommandHandler.handleCommand(event, CommandHandler.parser.parse(prefix, rawContent.toLowerCase()))
+      try {
+        CommandHandler.handleCommand(event, CommandHandler.parser.parse(prefix, rawContent.toLowerCase()))
+      } catch (e: InvalidCommand) {
+        val channel = event.channel
+        BotUtils.sendMessage(channel, e.usage(prefix))
+        logger.error { "${event.guild.name}#${channel.name}: ${e.reason}" }
+      }
     }
   }
 


### PR DESCRIPTION
Previously, in every `Command` implementation, there needed to be a DB call to obtain the prefix and handle the case where the command was used incorrectly and print the usage information. This resulted in a lot of code duplication, and unnecessary DB calls.

To alleviate that, I've created an exception, `InvalidCommand`, that would get thrown whenever the `Command` was used incorrectly. At which point the caller, `EventListener`, could provide a message to the user saying what went wrong. This makes it so that there's only one place where the error is handled freeing the commands to worry about doing what they need to do to perform the action requested by the user.

Closes #31 