### PR TITLE
Temporary Disable AutoJoin and AutoLeave

### DIFF
--- a/Rockerfile
+++ b/Rockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
 
 EXPORT /src/target/throw-voice-1.0-SNAPSHOT-release.zip /throw-voice-release.zip
 
-TAG gdragon/throw-voice:1.0.0-builder
+TAG gdragon/throw-voice:builder
 
 FROM openjdk:9-jre-slim
 MAINTAINER Jose V. Trigueros <jose@gdragon.tech>

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -47,6 +47,7 @@ object BotUtils {
    * Find biggest voice chanel that surpasses the Guild's autoJoin minimum
    */
   @JvmStatic
+  @Deprecated("This contains a bug, any code using this should stop for now", level = DeprecationLevel.ERROR)
   fun biggestChannel(guild: DiscordGuild): VoiceChannel? {
     val voiceChannels = guild.voiceChannels
 
@@ -57,7 +58,7 @@ object BotUtils {
         .filter { voiceChannel ->
           val channel = settings?.channels?.find { it.id.value == voiceChannel.idLong }
           val channelSize = voiceChannelSize(voiceChannel)
-          channel?.autoJoin?.let { it <= channelSize } ?: false
+          /*channel?.autoJoin?.let { it <= channelSize } ?: */false
         }
         .maxBy(BotUtils::voiceChannelSize)
     }

--- a/src/main/kotlin/tech/gdragon/TestApp.kt
+++ b/src/main/kotlin/tech/gdragon/TestApp.kt
@@ -63,7 +63,7 @@ fun testBiggestChannel() {
       override fun onGuildVoiceJoin(event: GuildVoiceJoinEvent) {
         println("event.guild = ${event.guild}")
         println("Joined ${event.channelJoined}")
-        println("Largest channel: ${BotUtils.biggestChannel(event.guild)}")
+//        println("Largest channel: ${BotUtils.biggestChannel(event.guild)}")
         super.onGuildVoiceJoin(event)
       }
 

--- a/src/main/kotlin/tech/gdragon/commands/settings/AutoJoin.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/AutoJoin.kt
@@ -13,7 +13,7 @@ class AutoJoin : Command {
     transaction {
       Channel
         .findOrCreate(channel.idLong, channel.name, channel.guild.idLong, channel.guild.name)
-        .forEach { it.autoJoin = autoJoin }
+//        .forEach { it.autoJoin = autoJoin }
     }
   }
 
@@ -22,7 +22,7 @@ class AutoJoin : Command {
    * channel is disabled.
    */
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
-    require(args.size >= 2) {
+    /*require(args.size >= 2) {
       throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
     }
 
@@ -70,9 +70,9 @@ class AutoJoin : Command {
         throw InvalidCommand(::usage, "Could not parse number argument: ${e.message}")
       } catch (e: IllegalArgumentException) {
         throw InvalidCommand(::usage, "Number must be positive: ${e.message}")
-      }
+      }*/
 
-    BotUtils.sendMessage(event.channel, message)
+    BotUtils.sendMessage(event.channel, ":no_entry_sign: _AutoJoin is currently disabled due to some bugs_")
   }
 
   override fun usage(prefix: String): String = "${prefix}autojoin [Voice Channel name | 'all'] [number | 'off']"

--- a/src/main/kotlin/tech/gdragon/commands/settings/AutoLeave.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/AutoLeave.kt
@@ -13,12 +13,12 @@ class AutoLeave : Command {
     transaction {
       Channel
         .findOrCreate(channel.idLong, channel.name, channel.guild.idLong, channel.guild.name)
-        .forEach { it.autoLeave = autoLeave }
+//        .forEach { it.autoLeave = autoLeave }
     }
   }
 
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
-    require(args.size >= 2) {
+    /*require(args.size >= 2) {
       throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
     }
 
@@ -49,9 +49,9 @@ class AutoLeave : Command {
         throw InvalidCommand(::usage, "Could not parse number argument: ${e.message}")
       } catch (e: IllegalArgumentException) {
         throw InvalidCommand(::usage, "Number must be positive: ${e.message}")
-      }
+      }*/
 
-    BotUtils.sendMessage(event.channel, message)
+    BotUtils.sendMessage(event.channel, ":no_entry_sign: _AutoLeave is currently disabled due to some bugs_")
   }
 
   override fun usage(prefix: String): String = "${prefix}autoleave [Voice Channel name | 'all'] [number]"

--- a/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
+++ b/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
@@ -50,7 +50,9 @@ class Channel(id: EntityID<Long>) : LongEntity(id) {
   }
 
   var name by Channels.name
+  @Deprecated("This feature is broken", level = DeprecationLevel.ERROR)
   var autoJoin by Channels.autoJoin
+  @Deprecated("This feature is broken", level = DeprecationLevel.ERROR)
   var autoLeave by Channels.autoLeave
   var settings by Settings referencedOn Channels.settings
 }

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -229,8 +229,10 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
         val recordingBaseUrl = (System.getenv("B2_BASE_URL") ?: "$b2ClientUrl/file") + "/$bucketName"
         val recordingUrl = "$recordingBaseUrl/$b2Filename"
 
-        val message = """|:microphone2: **Recording <#${voiceChannel?.id}> has been uploaded!**
+        val message = """|:microphone2: **Recording for <#${voiceChannel?.id}> has been uploaded!**
                          |$recordingUrl
+                         |
+                         |_Recording will only be available for 24hrs_
                          |""".trimMargin()
 
         BotUtils.sendMessage(channel, message)

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -5,9 +5,6 @@ import net.dv8tion.jda.core.entities.Game
 import net.dv8tion.jda.core.events.ReadyEvent
 import net.dv8tion.jda.core.events.guild.GuildJoinEvent
 import net.dv8tion.jda.core.events.guild.GuildLeaveEvent
-import net.dv8tion.jda.core.events.guild.voice.GuildVoiceJoinEvent
-import net.dv8tion.jda.core.events.guild.voice.GuildVoiceLeaveEvent
-import net.dv8tion.jda.core.events.guild.voice.GuildVoiceMoveEvent
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import net.dv8tion.jda.core.events.message.priv.PrivateMessageReceivedEvent
 import net.dv8tion.jda.core.hooks.ListenerAdapter
@@ -45,7 +42,7 @@ class EventListener : ListenerAdapter() {
   }
 
   // TODO: Add logging
-  override fun onGuildVoiceJoin(event: GuildVoiceJoinEvent) {
+/*  override fun onGuildVoiceJoin(event: GuildVoiceJoinEvent) {
     if (event.member == null || event.member.user == null || event.member.user.isBot)
       return
 
@@ -88,9 +85,9 @@ class EventListener : ListenerAdapter() {
         BotUtils.joinVoiceChannel(event.channelJoined, false)
       }
     }
-  }
+  }*/
 
-  override fun onGuildVoiceLeave(event: GuildVoiceLeaveEvent) {
+/*  override fun onGuildVoiceLeave(event: GuildVoiceLeaveEvent) {
     if (event.member == null || event.member.user == null || event.member.user.isBot)
       return
 
@@ -99,7 +96,7 @@ class EventListener : ListenerAdapter() {
 
       for (channel in settings.channels) {
         if (channel.id.value == event.channelLeft.idLong) {
-          return@transaction channel . autoLeave
+          return@transaction channel.autoLeave
         }
       }
 
@@ -128,9 +125,9 @@ class EventListener : ListenerAdapter() {
         BotUtils.joinVoiceChannel(biggest, false)
       }
     }
-  }
+  }*/
 
-  override fun onGuildVoiceMove(event: GuildVoiceMoveEvent) {
+/*  override fun onGuildVoiceMove(event: GuildVoiceMoveEvent) {
     if (event.member == null || event.member.user == null || event.member.user.isBot)
       return
 
@@ -206,7 +203,7 @@ class EventListener : ListenerAdapter() {
         BotUtils.joinVoiceChannel(event.channelJoined, false)
       }
     }
-  }
+  }*/
 
   override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {
     if (event.member == null || event.member.user == null || event.member.user.isBot)
@@ -311,12 +308,12 @@ class EventListener : ListenerAdapter() {
     }
 
     //check for servers to join
-    for (g in event.jda.guilds) {
+/*    for (g in event.jda.guilds) {
       val biggest = BotUtils.biggestChannel(g)
       if (biggest != null) {
         BotUtils.joinVoiceChannel(BotUtils.biggestChannel(g), false)
       }
-    }
+    }*/
   }
 }
 


### PR DESCRIPTION
A few users have been reporting that the bot leaves whenever someone leaves the voice channel, and doesn't autojoin at all. So in order to not interrupt recordings, these commands will be disabled until I find a fix.

Related #46 
Closes #49 