### PR TITLE
Rollbar Logging Improvements

### DIFF
--- a/src/main/kotlin/tech/gdragon/App.kt
+++ b/src/main/kotlin/tech/gdragon/App.kt
@@ -14,6 +14,7 @@ class App private constructor(port: Int, val clientId: String, val inviteUrl: St
     val uri = session.uri
 
     val response: NanoHTTPD.Response
+
     if (uri.toLowerCase().contains("ping")) {
       response = NanoHTTPD.newFixedLengthResponse("pong")
     } else {
@@ -41,9 +42,9 @@ class App private constructor(port: Int, val clientId: String, val inviteUrl: St
       // Connect to database
       Shim.initializeDatabase(dataDirectory + "/settings.db")
 
-      val bot = Bot(token)
-      val inviteUrl = bot.api.asBot().getInviteUrl(Bot.PERMISSIONS)
-      val app = App(Integer.parseInt(port), clientId, inviteUrl)
+//      val bot = Bot(token)
+//      val inviteUrl = bot.api.asBot().getInviteUrl(Bot.PERMISSIONS)
+      val app = App(Integer.parseInt(port), clientId, inviteUrl = "")
 
       try {
         val recordingsDir = dataDirectory + "/recordings/"

--- a/src/main/kotlin/tech/gdragon/discord/logging/util.kt
+++ b/src/main/kotlin/tech/gdragon/discord/logging/util.kt
@@ -1,0 +1,21 @@
+package tech.gdragon.discord.logging
+
+fun parseGuildInfo(body: String): Map<String, Any> {
+  val (guild, channel) = body.substringBefore(':', "#").split('#').let {
+    if(it.count() != 2)
+      listOf("","")
+    else
+      it
+  }
+  return mapOf("guild" to guild, "channel" to channel)
+}
+
+fun parseAudioFile(body: String): Map<String, Any> {
+  val (f,s) = body.split(" - ")
+  val filename = f.split(' ').last()
+  val size = s.slice(0 until 10).toDouble()
+
+  return mapOf("file" to mapOf("filename" to filename, "size" to size))
+}
+
+fun parseBody(log: String) = log.substringAfter(" - ")


### PR DESCRIPTION
Rollbar supports including custom fields when logging. For now, I'm polluting the Java file that handles the logging Log4j appender for Rollbar to include some parsing utilities that will extract Guild and Channel information as well as filename and file size when applicable. It's not the best, but we'll try it out, this will help me do some RQL queries to aggregate some data.

Additionally, I've also set up a Rollbar webhook endpoint that forwards the alert information to a Discord webhook so that the information can be posted to a Discord text channel.

Again, no bot improvements, but these will help me moving forward.