### PR TITLE
Fix AutoJoin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <jda.version>3.5.1_339</jda.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
-    <kotlin.version>1.2.21</kotlin.version>
+    <kotlin.version>1.2.30</kotlin.version>
     <main.class>tech.gdragon.App</main.class>
     <maven.compiler.source>1.9</maven.compiler.source>
     <maven.compiler.target>1.9</maven.compiler.target>

--- a/src/main/kotlin/tech/gdragon/App.kt
+++ b/src/main/kotlin/tech/gdragon/App.kt
@@ -85,7 +85,7 @@ class App private constructor(port: Int, val clientId: String, val inviteUrl: St
     fun main(args: Array<String>) {
       val token = System.getenv("BOT_TOKEN")
       val port = System.getenv("PORT")
-      val clientId = System.getenv("CLIENT_ID")
+      val clientId = System.getenv("CLIENT_ID") // TODO: Can we get rid of this w/o consequences?
       val dataDirectory = System.getenv("DATA_DIR")
 
       // Connect to database

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -3,7 +3,7 @@ package tech.gdragon
 import mu.KotlinLogging
 import net.dv8tion.jda.core.EmbedBuilder
 import net.dv8tion.jda.core.JDA
-import net.dv8tion.jda.core.entities.TextChannel
+import net.dv8tion.jda.core.entities.MessageChannel
 import net.dv8tion.jda.core.entities.User
 import net.dv8tion.jda.core.entities.VoiceChannel
 import net.dv8tion.jda.core.exceptions.InsufficientPermissionException
@@ -20,21 +20,22 @@ object BotUtils {
   /**
    * Send a DM to anyone in the voiceChannel unless they are in the blacklist
    */
-  @JvmStatic
-  fun alert(voiceChannel: VoiceChannel?) {
+  fun alert(channel: VoiceChannel, alertMessage: String) {
     transaction {
-      val guild = Guild.findById(voiceChannel?.guild?.idLong ?: 0)
+      val guild = Guild.findById(channel.guild.idLong)
       val blackList = guild?.settings?.alertBlacklist
       val message = EmbedBuilder()
-        .setAuthor("pawa", "https://www.pawabot.site/", voiceChannel?.jda?.selfUser?.avatarUrl)
+        .setAuthor("pawa", "https://www.pawabot.site/", channel.jda.selfUser.avatarUrl)
         .setColor(Color.RED)
-        .setTitle("Your audio is now being recorded in ${voiceChannel?.name} on `${voiceChannel?.guild?.name}`.")
-        .setDescription("Disable this alert with `${guild?.settings?.prefix}alerts off`")
+        .setTitle("Alert!")
+        .setDescription("""|$alertMessage
+                           |
+                           |Disable this alert with `${guild?.settings?.prefix}alerts off`""".trimMargin())
         .setThumbnail("http://www.freeiconspng.com/uploads/alert-icon-png-red-alert-round-icon-clip-art-3.png")
         .setTimestamp(OffsetDateTime.now())
         .build()
 
-      voiceChannel?.members
+      channel.members
         ?.map { it.user }
         ?.filter { user -> !user.isBot && blackList?.find { it.id.value == user.idLong } == null }
         ?.forEach { user ->
@@ -69,13 +70,14 @@ object BotUtils {
   /**
    * AutoJoin voice channel if it meets the autojoining criterion
    */
-  fun autoJoin(guild: DiscordGuild, channel: VoiceChannel): Unit {
+  fun autoJoin(guild: DiscordGuild, channel: VoiceChannel, onError: (InsufficientPermissionException) -> String? = { _ -> null }): String? {
     val channelMemberCount = voiceChannelSize(channel)
     logger.debug { "${guild.name}#${channel.name} - Channel member count: $channelMemberCount" }
 
-    transaction {
-      Guild.findById(guild.idLong)
-        ?.settings
+    return transaction {
+      val settings = Guild.findById(guild.idLong)?.settings
+
+      settings
         ?.channels
         ?.first { it.id.value == channel.idLong }
         ?.let {
@@ -83,11 +85,12 @@ object BotUtils {
           BotUtils.logger.debug { "${guild.name}#${channel.name} - AutoJoin value: $autoJoin" }
 
           if (autoJoin != null && channelMemberCount >= autoJoin) {
-            joinVoiceChannel(channel)
+            return@let joinVoiceChannel(channel, onError = onError)
           }
+
+          return@let null
         }
     }
-
   }
 
   fun isSelfBot(jda: JDA, user: User): Boolean {
@@ -98,12 +101,12 @@ object BotUtils {
    * General message sending utility with error logging
    */
   @JvmStatic
-  fun sendMessage(textChannel: TextChannel?, msg: String) {
+  fun sendMessage(textChannel: MessageChannel?, msg: String) {
     textChannel
       ?.sendMessage(msg)
       ?.queue(
         { m -> logger.debug("{}#{}: Send message - {}", m.guild.name, m.channel.name, m.contentDisplay) },
-        { t -> logger.error("${textChannel.guild.name}#${textChannel.name}: Error sending message - $msg", t) }
+        { t -> logger.error("#${textChannel.name}: Error sending message - $msg", t) }
       )
   }
 
@@ -112,9 +115,8 @@ object BotUtils {
    */
   fun voiceChannelSize(voiceChannel: VoiceChannel?): Int = voiceChannel?.members?.count() ?: 0
 
-  fun joinVoiceChannel(channel: VoiceChannel, warning: Boolean = false) {
-//    logger.info("{}#{}: Joining voice channel", channel?.guild?.name, channel?.name)
-
+  fun joinVoiceChannel(channel: VoiceChannel, warning: Boolean = false, onError: (InsufficientPermissionException) -> String? = { _ -> null }): String? {
+    // TODO: Bot warns about AFK channel but connects anyway lulz
     if (channel == channel.guild.afkChannel) {
       if (warning) { // TODO: wtf does this do again?
         transaction {
@@ -125,24 +127,36 @@ object BotUtils {
       }
     }
 
-    try {
-      val audioManager = channel.guild.audioManager
-      logger.debug { "${channel.guild.name}#${channel.name} - $audioManager" }
+    val audioManager = channel.guild.audioManager
+    val connectedChannel = audioManager?.connectedChannel
 
-      audioManager?.openAudioConnection(channel)
-      alert(channel)
-      transaction {
-        val volume = Guild.findById(channel.guild.idLong)?.settings?.volume?.toDouble() ?: 1.0
-        audioManager?.setReceivingHandler(CombinedAudioRecorderHandler(volume, channel))
+    if (connectedChannel?.idLong == channel.idLong) {
+      logger.debug { "${channel.guild.name}#${channel.name} - Already connected to ${channel.name}" }
+    } else {
+      // TODO: Before disconnect check if you need to autosave
+
+      try {
+        logger.info { "${channel.guild.name}#${channel.name} - Connecting to voice channel" }
+        audioManager?.openAudioConnection(channel)
+      } catch (e: InsufficientPermissionException) {
+        logger.warn { "${channel.guild.name}#${channel.name} - Need permission: ${e.permission}" }
+        return onError(e)
       }
-    } catch (e: InsufficientPermissionException) {
-      logger.error("Not enough permissions to join ${channel.name}", e)
+
       transaction {
-        val settings = Guild.findById(channel?.guild?.idLong ?: 0L)?.settings
-        val channel = channel.guild.getTextChannelById(settings?.defaultTextChannel ?: 0L)
-        sendMessage(channel, ":no_entry_sign: _I don't have permission to join **<#${channel?.id}>**._")
+        val volume = Guild.findById(channel.guild.idLong)
+          ?.settings
+          ?.volume
+          ?.toDouble()
+          ?: 1.0
+
+        audioManager?.setReceivingHandler(CombinedAudioRecorderHandler(volume, channel))
+        BotUtils.logger.debug { "${channel.guild.name}#${channel.name} - Audio Recorder Handler set" }
+        alert(channel, "Your audio is now being recorded in **<#${channel.id}>** on **${channel.guild.name}**.")
       }
     }
+
+    return null
   }
 
   @JvmStatic

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -133,11 +133,10 @@ object BotUtils {
     if (connectedChannel?.idLong == channel.idLong) {
       logger.debug { "${channel.guild.name}#${channel.name} - Already connected to ${channel.name}" }
     } else {
-      // TODO: Before disconnect check if you need to autosave
 
       try {
-        logger.info { "${channel.guild.name}#${channel.name} - Connecting to voice channel" }
         audioManager?.openAudioConnection(channel)
+        logger.info { "${channel.guild.name}#${channel.name} - Connected to voice channel" }
       } catch (e: InsufficientPermissionException) {
         logger.warn { "${channel.guild.name}#${channel.name} - Need permission: ${e.permission}" }
         return onError(e)
@@ -151,7 +150,6 @@ object BotUtils {
           ?: 1.0
 
         audioManager?.setReceivingHandler(CombinedAudioRecorderHandler(volume, channel))
-        BotUtils.logger.debug { "${channel.guild.name}#${channel.name} - Audio Recorder Handler set" }
         alert(channel, "Your audio is now being recorded in **<#${channel.id}>** on **${channel.guild.name}**.")
       }
     }

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -8,7 +8,6 @@ import net.dv8tion.jda.core.entities.User
 import net.dv8tion.jda.core.entities.VoiceChannel
 import net.dv8tion.jda.core.exceptions.InsufficientPermissionException
 import org.jetbrains.exposed.sql.transactions.transaction
-import org.slf4j.LoggerFactory
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.listener.CombinedAudioRecorderHandler
 import java.awt.Color
@@ -111,10 +110,7 @@ object BotUtils {
   /**
    * Returns the effective size of the voice channel, excluding bots.
    */
-  @JvmStatic
-  fun voiceChannelSize(voiceChannel: VoiceChannel?): Int {
-    return voiceChannel?.members?.count { !it.user.isBot } ?: 0
-  }
+  fun voiceChannelSize(voiceChannel: VoiceChannel?): Int = voiceChannel?.members?.count() ?: 0
 
   @JvmStatic
   fun joinVoiceChannel(voiceChannel: VoiceChannel?, warning: Boolean = false) {

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -1,7 +1,10 @@
 package tech.gdragon
 
+import mu.KotlinLogging
 import net.dv8tion.jda.core.EmbedBuilder
+import net.dv8tion.jda.core.JDA
 import net.dv8tion.jda.core.entities.TextChannel
+import net.dv8tion.jda.core.entities.User
 import net.dv8tion.jda.core.entities.VoiceChannel
 import net.dv8tion.jda.core.exceptions.InsufficientPermissionException
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -62,6 +65,11 @@ object BotUtils {
         }
         .maxBy(BotUtils::voiceChannelSize)
     }
+  }
+
+
+  fun isSelfBot(jda: JDA, user: User): Boolean {
+    return user.isBot && jda.selfUser.idLong == user.idLong
   }
 
   /**

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -47,7 +47,7 @@ object BotUtils {
    * Find biggest voice chanel that surpasses the Guild's autoJoin minimum
    */
   @JvmStatic
-  @Deprecated("This contains a bug, any code using this should stop for now", level = DeprecationLevel.ERROR)
+  @Deprecated("This contains a bug, any code using this should stop for now", level = DeprecationLevel.WARNING)
   fun biggestChannel(guild: DiscordGuild): VoiceChannel? {
     val voiceChannels = guild.voiceChannels
 
@@ -58,7 +58,7 @@ object BotUtils {
         .filter { voiceChannel ->
           val channel = settings?.channels?.find { it.id.value == voiceChannel.idLong }
           val channelSize = voiceChannelSize(voiceChannel)
-          /*channel?.autoJoin?.let { it <= channelSize } ?: */false
+          channel?.autoJoin?.let { it <= channelSize } ?: false
         }
         .maxBy(BotUtils::voiceChannelSize)
     }

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -128,10 +128,9 @@ object BotUtils {
     }
 
     val audioManager = channel.guild.audioManager
-    val connectedChannel = audioManager?.connectedChannel
 
-    if (connectedChannel?.idLong == channel.idLong) {
-      logger.debug { "${channel.guild.name}#${channel.name} - Already connected to ${channel.name}" }
+    if(audioManager?.isConnected == true) {
+      logger.debug { "${channel.guild.name}#${channel.name} - Already connected to ${audioManager.connectedChannel.name}" }
     } else {
 
       try {

--- a/src/main/kotlin/tech/gdragon/TestApp.kt
+++ b/src/main/kotlin/tech/gdragon/TestApp.kt
@@ -9,13 +9,11 @@ import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
-import synapticloop.b2.B2ApiClient
 import tech.gdragon.db.Shim
 import tech.gdragon.db.dao.Alias
 import tech.gdragon.db.dao.Channel
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.db.table.Tables
-import java.io.File
 import java.sql.Connection
 
 fun dropAllTables() {
@@ -80,9 +78,9 @@ fun testAlerts() {
   JDABuilder(AccountType.BOT)
     .setToken(System.getenv("TOKEN"))
     .addEventListener(object : ListenerAdapter() {
-      override fun onGuildVoiceJoin(event: GuildVoiceJoinEvent?) {
-        println("Sending alerts to users that joined ${event?.channelJoined}.")
-        BotUtils.alert(event?.channelJoined)
+      override fun onGuildVoiceJoin(event: GuildVoiceJoinEvent) {
+        println("Sending alerts to users that joined ${event.channelJoined}.")
+        BotUtils.alert(event.channelJoined, "")
         super.onGuildVoiceJoin(event)
       }
     })

--- a/src/main/kotlin/tech/gdragon/commands/audio/Save.kt
+++ b/src/main/kotlin/tech/gdragon/commands/audio/Save.kt
@@ -21,7 +21,7 @@ class Save : Command {
         val voiceChannel = event.guild.audioManager.connectedChannel
         val audioReceiveHandler = event.guild.audioManager.receiveHandler as CombinedAudioRecorderHandler
 
-        BotUtils.sendMessage(event.channel, ":floppy_disk: **Saving <#${voiceChannel.id}> recording...**")
+        BotUtils.sendMessage(event.channel, ":floppy_disk: **Saving <#${voiceChannel.id}>'s recording...**")
         if (args.isEmpty()) {
           audioReceiveHandler.saveRecording(voiceChannel, event.channel)
           ""

--- a/src/main/kotlin/tech/gdragon/commands/misc/Join.kt
+++ b/src/main/kotlin/tech/gdragon/commands/misc/Join.kt
@@ -37,8 +37,10 @@ class Join : Command {
               }
             }
 
-            BotUtils.joinVoiceChannel(voiceChannel, true)
-            ":red_circle: **Recording on <#${voiceChannel.id}>**"
+
+            BotUtils.joinVoiceChannel(voiceChannel, true) { ex ->
+              ":no_entry_sign: _Cannot join **<#${event.channel.id}>**, need permission:_ ```${ex.permission}```"
+            } ?: ":red_circle: **Recording on <#${voiceChannel.id}>**"
           }
         }
 

--- a/src/main/kotlin/tech/gdragon/commands/settings/AutoJoin.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/AutoJoin.kt
@@ -13,7 +13,7 @@ class AutoJoin : Command {
     transaction {
       Channel
         .findOrCreate(channel.idLong, channel.name, channel.guild.idLong, channel.guild.name)
-//        .forEach { it.autoJoin = autoJoin }
+        .forEach { it.autoJoin = autoJoin }
     }
   }
 
@@ -22,7 +22,7 @@ class AutoJoin : Command {
    * channel is disabled.
    */
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
-    /*require(args.size >= 2) {
+    require(args.size >= 2) {
       throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
     }
 
@@ -70,9 +70,9 @@ class AutoJoin : Command {
         throw InvalidCommand(::usage, "Could not parse number argument: ${e.message}")
       } catch (e: IllegalArgumentException) {
         throw InvalidCommand(::usage, "Number must be positive: ${e.message}")
-      }*/
+      }
 
-    BotUtils.sendMessage(event.channel, ":no_entry_sign: _AutoJoin is currently disabled due to some bugs_")
+    BotUtils.sendMessage(event.channel, message)
   }
 
   override fun usage(prefix: String): String = "${prefix}autojoin [Voice Channel name | 'all'] [number | 'off']"

--- a/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
+++ b/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
@@ -50,7 +50,6 @@ class Channel(id: EntityID<Long>) : LongEntity(id) {
   }
 
   var name by Channels.name
-  @Deprecated("This feature is broken", level = DeprecationLevel.ERROR)
   var autoJoin by Channels.autoJoin
   @Deprecated("This feature is broken", level = DeprecationLevel.ERROR)
   var autoLeave by Channels.autoLeave

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -204,8 +204,7 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
     }
 
     val recordingSizeInMB = recording.length().toDouble() / 1024 / 1024
-    logger.info("Saving audio file '{}' from {} on {} of size {} MB.",
-      recording.name, voiceChannel, channel?.guild?.name, recordingSizeInMB)
+    logger.info("{}#{}: Saving audio clip {} - {}MB.",  voiceChannel?.guild?.name, voiceChannel?.name, recording.name, recordingSizeInMB)
 
     uploadRecording(recording, recordingSizeInMB, voiceChannel, channel)
   }

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -6,6 +6,8 @@ import net.dv8tion.jda.core.events.ReadyEvent
 import net.dv8tion.jda.core.events.guild.GuildJoinEvent
 import net.dv8tion.jda.core.events.guild.GuildLeaveEvent
 import net.dv8tion.jda.core.events.guild.voice.GuildVoiceJoinEvent
+import net.dv8tion.jda.core.events.guild.voice.GuildVoiceLeaveEvent
+import net.dv8tion.jda.core.events.guild.voice.GuildVoiceMoveEvent
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import net.dv8tion.jda.core.events.message.priv.PrivateMessageReceivedEvent
 import net.dv8tion.jda.core.hooks.ListenerAdapter
@@ -42,12 +44,9 @@ class EventListener : ListenerAdapter() {
     logger.info{"Left server '${event.guild.name}', connected to ${event.jda.guilds.size} guilds."}
   }
 
-  // TODO: Add logging
   override fun onGuildVoiceJoin(event: GuildVoiceJoinEvent) {
-    logger.info { "${event.guild.name}#${event.channelJoined.name} - ${event.member.effectiveName} joined voice channel" }
-    val audioManager = event.guild.audioManager
+    logger.debug { "${event.guild.name}#${event.channelJoined.name} - ${event.member.effectiveName} joined voice channel" }
 
-    // TODO verify this logic
     val biggestChannel = BotUtils.biggestChannel(event.guild)
     logger.info("${event.guild.name}#${event.channelJoined.name} - ${biggestChannel?.name} is the biggest channel")
 
@@ -56,7 +55,9 @@ class EventListener : ListenerAdapter() {
     }
   }
 
-/*  override fun onGuildVoiceLeave(event: GuildVoiceLeaveEvent) {
+  override fun onGuildVoiceLeave(event: GuildVoiceLeaveEvent) {
+    logger.debug { "${event.guild.name}#${event.channelLeft.name} - ${event.member.effectiveName} left voice channel" }
+    /*
     if (event.member == null || event.member.user == null || event.member.user.isBot)
       return
 
@@ -94,9 +95,12 @@ class EventListener : ListenerAdapter() {
         BotUtils.joinVoiceChannel(biggest, false)
       }
     }
-  }*/
+    */
+  }
 
-/*  override fun onGuildVoiceMove(event: GuildVoiceMoveEvent) {
+  override fun onGuildVoiceMove(event: GuildVoiceMoveEvent) {
+    logger.debug { "${event.guild.name}#${event.channelLeft.name}#${event.channelJoined.name} - ${event.member.effectiveName} moved voice channels" }
+    /*
     if (event.member == null || event.member.user == null || event.member.user.isBot)
       return
 
@@ -172,7 +176,8 @@ class EventListener : ListenerAdapter() {
         BotUtils.joinVoiceChannel(event.channelJoined, false)
       }
     }
-  }*/
+    */
+  }
 
   override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {
     if (event.member == null || event.member.user == null || event.member.user.isBot)

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -5,6 +5,7 @@ import net.dv8tion.jda.core.entities.Game
 import net.dv8tion.jda.core.events.ReadyEvent
 import net.dv8tion.jda.core.events.guild.GuildJoinEvent
 import net.dv8tion.jda.core.events.guild.GuildLeaveEvent
+import net.dv8tion.jda.core.events.guild.voice.GuildVoiceJoinEvent
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import net.dv8tion.jda.core.events.message.priv.PrivateMessageReceivedEvent
 import net.dv8tion.jda.core.hooks.ListenerAdapter
@@ -42,50 +43,18 @@ class EventListener : ListenerAdapter() {
   }
 
   // TODO: Add logging
-/*  override fun onGuildVoiceJoin(event: GuildVoiceJoinEvent) {
-    if (event.member == null || event.member.user == null || event.member.user.isBot)
-      return
-
+  override fun onGuildVoiceJoin(event: GuildVoiceJoinEvent) {
+    logger.info { "${event.guild.name}#${event.channelJoined.name} - ${event.member.effectiveName} joined voice channel" }
     val audioManager = event.guild.audioManager
 
-    if (audioManager.isConnected) {
-      val newSize = BotUtils.voiceChannelSize(event.channelJoined)
-      val botSize = BotUtils.voiceChannelSize(audioManager.connectedChannel)
-      val min = transaction {
-        val settings = tech.gdragon.db.dao.Guild.findById(event.guild.idLong)!!.settings
+    // TODO verify this logic
+    val biggestChannel = BotUtils.biggestChannel(event.guild)
+    logger.info("${event.guild.name}#${event.channelJoined.name} - ${biggestChannel?.name} is the biggest channel")
 
-        for (channel in settings.channels) {
-          if (channel.id.value == event.channelJoined.idLong) {
-            val autoJoin = channel.autoJoin
-            return@transaction autoJoin ?: Integer.MAX_VALUE
-          }
-        }
-
-        Integer.MAX_VALUE
-      }
-
-      if (newSize >= min && botSize < newSize) {  //check for tie with old server
-        val autoSave = transaction {
-          val settings = tech.gdragon.db.dao.Guild.findById(event.guild.idLong)!!.settings
-          settings.autoSave
-        }
-
-        if (autoSave) {
-          val receiveHandler = audioManager.receiveHandler as CombinedAudioRecorderHandler
-          receiveHandler.saveRecording(event.channelJoined, event.member.defaultChannel)
-        }
-
-        BotUtils.joinVoiceChannel(event.channelJoined, false)
-      }
-
-    } else {
-      val biggestChannel = BotUtils.biggestChannel(event.guild)
-
-      if (biggestChannel != null) {
-        BotUtils.joinVoiceChannel(event.channelJoined, false)
-      }
+    if (biggestChannel != null) {
+      BotUtils.joinVoiceChannel(event.channelJoined, false)
     }
-  }*/
+  }
 
 /*  override fun onGuildVoiceLeave(event: GuildVoiceLeaveEvent) {
     if (event.member == null || event.member.user == null || event.member.user.isBot)

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -45,14 +45,15 @@ class EventListener : ListenerAdapter() {
   }
 
   override fun onGuildVoiceJoin(event: GuildVoiceJoinEvent) {
-    logger.debug { "${event.guild.name}#${event.channelJoined.name} - ${event.member.effectiveName} joined voice channel" }
+    val user = event.member.user
+    logger.debug { "${event.guild.name}#${event.channelJoined.name} - ${user.name} joined voice channel" }
 
-    val biggestChannel = BotUtils.biggestChannel(event.guild)
-    logger.info("${event.guild.name}#${event.channelJoined.name} - ${biggestChannel?.name} is the biggest channel")
-
-    if (biggestChannel != null) {
-      BotUtils.joinVoiceChannel(event.channelJoined, false)
+    if(BotUtils.isSelfBot(event.jda, user)) {
+      logger.debug { "${event.guild.name}#${event.channelJoined.name} - ${user.name} is self-bot" }
+      return
     }
+
+    BotUtils.autoJoin(event.guild, event.channelJoined)
   }
 
   override fun onGuildVoiceLeave(event: GuildVoiceLeaveEvent) {
@@ -99,7 +100,16 @@ class EventListener : ListenerAdapter() {
   }
 
   override fun onGuildVoiceMove(event: GuildVoiceMoveEvent) {
-    logger.debug { "${event.guild.name}#${event.channelLeft.name}#${event.channelJoined.name} - ${event.member.effectiveName} moved voice channels" }
+    val user = event.member.user
+    logger.debug { "${event.guild.name}#${event.channelLeft.name} - ${user.name} left voice channel" }
+    logger.debug { "${event.guild.name}#${event.channelJoined.name} - ${user.name} joined voice channel" }
+
+    if(BotUtils.isSelfBot(event.jda, user)) {
+      logger.debug { "${event.guild.name}#${event.channelJoined.name} - ${user.name} is self-bot" }
+      return
+    }
+
+    BotUtils.autoJoin(event.guild, event.channelJoined)
     /*
     if (event.member == null || event.member.user == null || event.member.user.isBot)
       return

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -63,45 +63,6 @@ class EventListener : ListenerAdapter() {
 
   override fun onGuildVoiceLeave(event: GuildVoiceLeaveEvent) {
     logger.debug { "${event.guild.name}#${event.channelLeft.name} - ${event.member.effectiveName} left voice channel" }
-    /*
-    if (event.member == null || event.member.user == null || event.member.user.isBot)
-      return
-
-    val min = transaction {
-      val settings = tech.gdragon.db.dao.Guild.findById(event.guild.idLong)!!.settings
-
-      for (channel in settings.channels) {
-        if (channel.id.value == event.channelLeft.idLong) {
-          return@transaction channel.autoLeave
-        }
-      }
-
-      Integer.MAX_VALUE
-    }
-
-    val size = BotUtils.voiceChannelSize(event.channelLeft)
-
-    val audioManager = event.guild.audioManager
-
-    if (size <= min && audioManager.connectedChannel === event.channelLeft) {
-      val autoSave = transaction {
-        val settings = tech.gdragon.db.dao.Guild.findById(event.guild.idLong)!!.settings
-        settings.autoSave
-      }
-
-      if (autoSave) {
-        val receiveHandler = audioManager.receiveHandler as CombinedAudioRecorderHandler
-        receiveHandler.saveRecording(event.channelLeft, event.member.defaultChannel)
-      }
-
-      BotUtils.leaveVoiceChannel(audioManager.connectedChannel)
-
-      val biggest = BotUtils.biggestChannel(event.guild)
-      if (biggest != null) {
-        BotUtils.joinVoiceChannel(biggest, false)
-      }
-    }
-    */
   }
 
   override fun onGuildVoiceMove(event: GuildVoiceMoveEvent) {
@@ -120,83 +81,6 @@ class EventListener : ListenerAdapter() {
          |""".trimMargin()
     }
     errorMessage?.let { BotUtils.alert(event.channelJoined, it) }
-    /*
-    if (event.member == null || event.member.user == null || event.member.user.isBot)
-      return
-
-    val audioManager = event.guild.audioManager
-
-    if (audioManager.isConnected) {
-      val newSize = BotUtils.voiceChannelSize(event.channelJoined)
-      val botSize = BotUtils.voiceChannelSize(audioManager.connectedChannel)
-
-      val min = transaction {
-        val settings = tech.gdragon.db.dao.Guild.findById(event.guild.idLong)!!.settings
-
-        for (channel in settings.channels) {
-          if (channel.id.value == event.channelJoined.idLong) {
-            val autoJoin = channel.autoJoin
-            return@transaction autoJoin ?: Integer.MAX_VALUE
-          }
-        }
-
-        Integer.MAX_VALUE
-      }
-
-      if (newSize >= min && botSize < newSize) {  //check for tie with old server
-        val autoSave = transaction {
-          val settings = Guild.findById(event.guild.idLong)?.settings
-          settings?.autoSave
-        }
-
-        if (autoSave == true) {
-          val receiveHandler = audioManager.receiveHandler as CombinedAudioRecorderHandler
-          receiveHandler.saveRecording(event.channelLeft, event.member.defaultChannel)
-        }
-
-        BotUtils.joinVoiceChannel(event.channelJoined, false)
-      }
-
-    } else {
-      val biggestChannel = BotUtils.biggestChannel(event.guild)
-      if (biggestChannel != null) {
-        BotUtils.joinVoiceChannel(biggestChannel, false)
-      }
-    }
-
-    //Check if bot needs to leave old channel
-    val min = transaction {
-      val settings = tech.gdragon.db.dao.Guild.findById(event.guild.idLong)!!.settings
-
-      for (channel in settings.channels) {
-        if (channel.id.value == event.channelJoined.idLong) {
-          return@transaction channel.autoLeave
-        }
-      }
-
-      0 // TODO, weeeeird, fix these loops
-    }
-    val size = BotUtils.voiceChannelSize(event.channelLeft)
-
-    if (audioManager.isConnected && size <= min && audioManager.connectedChannel === event.channelLeft) {
-      val autoSave = transaction {
-        val settings = Guild.findById(event.guild.idLong)?.settings
-        settings?.autoSave
-      }
-
-      if (autoSave == true) {
-        val receiveHandler = audioManager.receiveHandler as CombinedAudioRecorderHandler
-        receiveHandler.saveRecording(event.channelLeft, event.member.defaultChannel)
-      }
-
-      BotUtils.leaveVoiceChannel(audioManager.connectedChannel)
-
-      val biggest = BotUtils.biggestChannel(event.guild)
-      if (biggest != null) {
-        BotUtils.joinVoiceChannel(event.channelJoined, false)
-      }
-    }
-    */
   }
 
   override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {

--- a/src/main/kotlin/tech/gdragon/listener/VoiceChannelListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/VoiceChannelListener.kt
@@ -1,0 +1,26 @@
+package tech.gdragon.listener
+
+import mu.KotlinLogging
+import net.dv8tion.jda.core.events.channel.voice.VoiceChannelCreateEvent
+import net.dv8tion.jda.core.events.channel.voice.VoiceChannelDeleteEvent
+import net.dv8tion.jda.core.events.channel.voice.update.VoiceChannelUpdateNameEvent
+import net.dv8tion.jda.core.hooks.ListenerAdapter
+
+class VoiceChannelListener : ListenerAdapter() {
+  private val logger = KotlinLogging.logger {}
+
+  override fun onVoiceChannelCreate(event: VoiceChannelCreateEvent) {
+    logger.debug { "Creating Channel: ${event.channel}" }
+    super.onVoiceChannelCreate(event)
+  }
+
+  override fun onVoiceChannelDelete(event: VoiceChannelDeleteEvent) {
+    logger.debug { "Deleting Channel: ${event.channel}" }
+    super.onVoiceChannelDelete(event)
+  }
+
+  override fun onVoiceChannelUpdateName(event: VoiceChannelUpdateNameEvent) {
+    logger.debug { "Updating Channel: ${event.channel}" }
+    super.onVoiceChannelUpdateName(event)
+  }
+}


### PR DESCRIPTION
The previous implementation of AutoJoin was causing issues so it had to be disabled for the 1.0.0 release, but this PR fixes those problems. The previous stuff was too confusing, so instead of trying to find the issues, it was chucked and simplified.

There are a few changes to how it works:

- If the bot is not currently in a channel, it'll auto join if the number of members in the voice channel is greater than or equal to the value set by the `autojoin` command, **this now includes bots**.
- If the bot is already in a channel, it will not leave when switching between channels that meet the first criteria. _Example, if channel-1 and channel-2 have autojoin of 1, then if bot isn't in any channel and you join channel-1 the bot will autojoin channel-1, but if you go from channel-1 to channel-2 or if someone else joins channel-2 then the bot will stay in channel-1 until told to `leave`._

The bot watches everyone's actions, so following these rules would prevent the case where someone not in the intended recording channel, joins a different channel and accidentally takes the bot with them.

Closes #57 
Fixes #54 