### PR TITLE
Workaround: Bot not receiving audio from voice channel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </scm>
 
   <properties>
-    <jda.version>3.5.1_339</jda.version>
+    <jda.version>3.5.1_352</jda.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     <kotlin.version>1.2.30</kotlin.version>
     <main.class>tech.gdragon.App</main.class>

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -10,8 +10,11 @@ import net.dv8tion.jda.core.exceptions.InsufficientPermissionException
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.listener.CombinedAudioRecorderHandler
+import tech.gdragon.listener.SilenceAudioSendHandler
 import java.awt.Color
 import java.time.OffsetDateTime
+import java.util.*
+import kotlin.concurrent.schedule
 import net.dv8tion.jda.core.entities.Guild as DiscordGuild
 
 object BotUtils {
@@ -148,7 +151,13 @@ object BotUtils {
           ?.toDouble()
           ?: 1.0
 
+        val audioSendHandler = SilenceAudioSendHandler()
+        // Only send 5 seconds of audio at the beginning of the recording see: https://github.com/DV8FromTheWorld/JDA/issues/653
+        Timer().schedule(5 * 1000) {
+          audioSendHandler.canProvide = false
+        }
         audioManager?.setReceivingHandler(CombinedAudioRecorderHandler(volume, channel, defaultChannel))
+        audioManager?.sendingHandler = audioSendHandler
         alert(channel, "Your audio is now being recorded in **<#${channel.id}>** on **${channel.guild.name}**.")
       }
     }
@@ -169,6 +178,7 @@ object BotUtils {
     logger.info("{}#{}: Leaving voice channel", guild?.name, voiceChannel?.name)
     audioManager?.apply {
       setReceivingHandler(null)
+      sendingHandler = null
       closeAudioConnection()
       logger.info("{}#{}: Destroyed audio handlers", guild.name, voiceChannel.name)
     }

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -85,7 +85,7 @@ object BotUtils {
           BotUtils.logger.debug { "${guild.name}#${channel.name} - AutoJoin value: $autoJoin" }
 
           if (autoJoin != null && channelMemberCount >= autoJoin) {
-            return@let joinVoiceChannel(channel, onError = onError)
+            return@let joinVoiceChannel(channel, guild.defaultChannel!!, onError = onError)
           }
 
           return@let null
@@ -115,7 +115,7 @@ object BotUtils {
    */
   fun voiceChannelSize(voiceChannel: VoiceChannel?): Int = voiceChannel?.members?.count() ?: 0
 
-  fun joinVoiceChannel(channel: VoiceChannel, warning: Boolean = false, onError: (InsufficientPermissionException) -> String? = { _ -> null }): String? {
+  fun joinVoiceChannel(channel: VoiceChannel, defaultChannel: MessageChannel, warning: Boolean = false, onError: (InsufficientPermissionException) -> String? = { _ -> null }): String? {
     // TODO: Bot warns about AFK channel but connects anyway lulz
     if (channel == channel.guild.afkChannel) {
       if (warning) { // TODO: wtf does this do again?
@@ -148,7 +148,7 @@ object BotUtils {
           ?.toDouble()
           ?: 1.0
 
-        audioManager?.setReceivingHandler(CombinedAudioRecorderHandler(volume, channel))
+        audioManager?.setReceivingHandler(CombinedAudioRecorderHandler(volume, channel, defaultChannel))
         alert(channel, "Your audio is now being recorded in **<#${channel.id}>** on **${channel.guild.name}**.")
       }
     }

--- a/src/main/kotlin/tech/gdragon/TestApp.kt
+++ b/src/main/kotlin/tech/gdragon/TestApp.kt
@@ -15,7 +15,6 @@ import tech.gdragon.db.dao.Alias
 import tech.gdragon.db.dao.Channel
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.db.table.Tables
-import java.io.File
 import java.sql.Connection
 
 fun dropAllTables() {

--- a/src/main/kotlin/tech/gdragon/commands/misc/Join.kt
+++ b/src/main/kotlin/tech/gdragon/commands/misc/Join.kt
@@ -37,8 +37,7 @@ class Join : Command {
               }
             }
 
-
-            BotUtils.joinVoiceChannel(voiceChannel, true) { ex ->
+            BotUtils.joinVoiceChannel(voiceChannel, event.channel, true) { ex ->
               ":no_entry_sign: _Cannot join **<#${event.channel.id}>**, need permission:_ ```${ex.permission}```"
             } ?: ":red_circle: **Recording on <#${voiceChannel.id}>**"
           }

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -6,7 +6,9 @@ import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
+import mu.KotlinLogging
 import net.dv8tion.jda.core.audio.AudioReceiveHandler
+import net.dv8tion.jda.core.audio.AudioSendHandler
 import net.dv8tion.jda.core.audio.CombinedAudio
 import net.dv8tion.jda.core.audio.UserAudio
 import net.dv8tion.jda.core.entities.MessageChannel
@@ -273,4 +275,26 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
   }
 
   override fun handleUserAudio(userAudio: UserAudio?) = TODO("Not implemented.")
+}
+
+class SilenceAudioSendHandler: AudioSendHandler {
+  private val logger = KotlinLogging.logger {  }
+  var canProvide = true
+    set(value) {
+      logger.debug { "canProvide toggling from $canProvide to $value" }
+      field = value
+    }
+
+  override fun provide20MsAudio(): ByteArray {
+    val silence = arrayOf(0xF8.toByte(), 0xFF.toByte(), 0xFE.toByte())
+    return silence.toByteArray()
+  }
+
+  override fun canProvide(): Boolean {
+    return canProvide
+  }
+
+  override fun isOpus(): Boolean {
+    return true
+  }
 }


### PR DESCRIPTION
It seems like there's a [bug](https://github.com/DV8FromTheWorld/JDA/issues/653) with JDA that prevents audio from reaching the bot even if it joined unless the bot first sends audio to the voice channel. To get around this, I've created a `SilenceAudioSendHandler` that provides silence. There's another thread that stops it from sending audio after 5 seconds.