### PR TITLE
Fix log filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>com.rollbar</groupId>
       <artifactId>rollbar-java</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.squareup</groupId>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -13,7 +13,7 @@
       <accessToken>${env:ROLLBAR_TOKEN}</accessToken>
       <environment>${env:ROLLBAR_ENV}</environment>
       <PatternLayout pattern="${globalPattern}"/>
-      <RegexFilter regex=".*synapticloop\.b2\.response\.B2AuthorizeAccountResponse.*" onMatch="DENY"/>
+      <RegexFilter regex=".*Found an unexpected key.*" onMatch="DENY" onMismatch="ACCEPT"/>
     </Rollbar>
   </Appenders>
   <Loggers>


### PR DESCRIPTION
I mistakenly thought that `RegexFilter` in Log4j2 would look at the entire log message, but it turns out it only looks at the actual log message, not the namespace. So this was excluding all the logs going to Rollbar. For now, I'm going to be just filtering the _exact_ warning message that I want to filter from `synapticloop.b2.response`.