### PR TITLE
Add fabric8's run-java.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.5-jdk-9-slim as builder
-WORKDIR /src
-COPY . /src
+WORKDIR /app
+COPY . /app
 
 RUN apt-get update && apt-get install -y \
   git \
@@ -28,7 +28,7 @@ ENV DATA_DIR $APP_DIR/data
 
 WORKDIR $APP_DIR
 
-COPY --from=builder /src/target/throw-voice-*-release.zip /tmp/throw-voice-release.zip
+COPY --from=builder /app/target/throw-voice-*-release.zip /tmp/throw-voice-release.zip
 RUN unzip -d $APP_DIR /tmp/throw-voice-release.zip
 
 VOLUME $DATA_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,16 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 ENV APP_DIR /app
 ENV DATA_DIR $APP_DIR/data
 
+ENV JAVA_LIB_DIR lib/*
+ENV JAVA_MAIN_CLASS tech.gdragon.App
+
 WORKDIR $APP_DIR
 
 COPY --from=builder /app/target/throw-voice-*-release.zip /tmp/throw-voice-release.zip
 RUN unzip -d $APP_DIR /tmp/throw-voice-release.zip
 
+ADD https://cdn.rawgit.com/fabric8io-images/run-java-sh/v1.2.0/fish-pepper/run-java-sh/fp-files/run-java.sh $APP_DIR
+
 VOLUME $DATA_DIR
 
-CMD ["sh", "-c", "/usr/bin/java ${JAVA_OPTS} -cp *:lib/* tech.gdragon.App"]
+CMD ["sh", "run-java.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '3'
 services:
   pawa:
-    image: gdragon/throw-voice:1.1.0
+    image: gdragon/throw-voice:1.2.0-beta
     env_file:
       - ${ENV:-sample}-b2.env
       - ${ENV:-sample}-bot.env
       - ${ENV:-sample}-rollbar.env
     environment:
-      - JAVA_OPTS=--add-modules java.xml.bind -Xmx700m
+      - JAVA_OPTIONS=--add-modules java.xml.bind
       - TZ=America/Denver
     volumes:
       - ./data:/app/data


### PR DESCRIPTION
It turns out that running Java inside a Docker container is much more complicated than just `java -jar`. There are implications when it comes to considering memory and CPUs. The team at fabric8 has created this script that automatically figures all that out.

Here we add it as part of the Dockerfile and use that to run the bot.

Closes #51 