### PR TITLE
Alerts settings on multiple servers

### DIFF
--- a/src/main/kotlin/tech/gdragon/commands/settings/Alerts.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/Alerts.kt
@@ -9,6 +9,17 @@ import tech.gdragon.db.dao.Guild
 import tech.gdragon.db.dao.User
 import tech.gdragon.db.table.Tables.Users
 
+fun configureAlerts(userId: String, guildId: Long, enable: Boolean) {
+  transaction {
+    val settings = Guild.findById(guildId)?.settings!!
+    val user = User.findOrCreate(userId, settings)
+
+    if (enable) {
+      user.delete()
+    }
+  }
+}
+
 class Alerts : Command {
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
     val guildId = event.guild.idLong

--- a/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
+++ b/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
@@ -102,14 +102,14 @@ class Settings(id: EntityID<Long>) : LongEntity(id) {
 class User(id: EntityID<Long>) : LongEntity(id) {
   companion object : LongEntityClass<User>(Users) {
     @JvmStatic
-    fun findOrCreate(id: Long, name: String, settings: Settings): User = transaction {
+    fun findOrCreate(id: String, settings: Settings): User = transaction {
       val users = User.find {
-        (Users.id eq id) and (Users.settings eq settings.id)
+        (Users.name eq id) and (Users.settings eq settings.id)
       }
 
       if (users.empty()) {
-        User.new(id) {
-          this.name = name
+        User.new {
+          this.name = id
           this.settings = settings
         }
       } else {


### PR DESCRIPTION
If a user and the bot were members of multiple servers the `!alerts` command would behave incorrectly because the primary key for the table that handles alert settings was the user id, so there could only be _one_ entry in that table per user, but what I want is one entry per user per server.

Furthermore, this was exacerbated when calling `!alerts` in a private conversation with the bot as commands where the alerts settings would be applied globally.

_I'm carrying some technical debt, instead of recreating the `Users` table, I'm re-using the `name` column as now the Discord `user.id`, which is not clear. Once #9 is complete, I will make that change, but right now porting tables isn't trivial._