### PR TITLE
Handle RestAction 50007

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </scm>
 
   <properties>
-    <jda.version>3.6.0_354</jda.version>
+    <jda.version>3.6.0_356</jda.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     <kotlin.version>1.2.31</kotlin.version>
     <main.class>tech.gdragon.App</main.class>

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -132,8 +132,8 @@ object BotUtils {
       if (warning) { // TODO: wtf does this do again?
         transaction {
           val settings = Guild.findById(channel.guild.idLong)?.settings
-          val channel = channel.guild.getTextChannelById(settings?.defaultTextChannel ?: 0L)
-          sendMessage(channel, ":no_entry_sign: _I'm not allowed to join AFK channels._")
+          val textChannel = channel.guild.getTextChannelById(settings?.defaultTextChannel ?: 0L)
+          sendMessage(textChannel, ":no_entry_sign: _I'm not allowed to join AFK channels._")
         }
       }
     }

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -4,9 +4,9 @@ import mu.KotlinLogging
 import net.dv8tion.jda.core.EmbedBuilder
 import net.dv8tion.jda.core.JDA
 import net.dv8tion.jda.core.entities.MessageChannel
-import net.dv8tion.jda.core.entities.TextChannel
 import net.dv8tion.jda.core.entities.User
 import net.dv8tion.jda.core.entities.VoiceChannel
+import net.dv8tion.jda.core.exceptions.ErrorResponseException
 import net.dv8tion.jda.core.exceptions.InsufficientPermissionException
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.db.dao.Guild
@@ -43,8 +43,12 @@ object BotUtils {
         ?.map { it.user }
         ?.filter { user -> !user.isBot && blackList?.find { it.id.value == user.idLong } == null }
         ?.forEach { user ->
-          user.openPrivateChannel().queue { channel ->
-            channel.sendMessage(message).queue()
+          user.openPrivateChannel().queue { privateChannel ->
+            privateChannel.sendMessage(message).queue(null, {
+              BotUtils.logger.warn {
+                "${channel.guild.name}#${channel.name}: Could not alert ${user.name}"
+              }
+            })
           }
         }
     }


### PR DESCRIPTION
When trying to alert a user that the channel is being recorded, the bot would sometimes throw an exception if the user had DMs disabled. Instead of just barfing, I've added a callback that handles the condition where the user is not accepting messages. For now, that action only logs it as a warning, as it doesn't break anything.