### PR TITLE
Improve CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ jobs:
 
   coverage:
     <<: *defafults
+    docker:
+      - image: circleci/buildpack-deps:curl
     steps:
         - attach_workspace:
             at: ~/pawa/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,12 +54,12 @@ jobs:
       - checkout
       - run: |
           VCS_REF=$(git rev-parse --short HEAD)
-          [[ -z "${CIRCLE_TAG}" ]] && VERSION=${CIRCLE_TAG} || VERSION=1.2.0.${CIRCLE_BUILD_NUM}
+          [[ -v CIRCLE_TAG ]] && VERSION=${CIRCLE_TAG} || VERSION=1.2.0.${CIRCLE_BUILD_NUM}
           BUILD_DATE=$(date +%FT%T.%z)
           echo ${VERSION}
-          docker build --quiet --cache-from gdragon/throw-voice:latest -t gdragon/throw-voice:${VERSION} --build-arg VCS_REF=${VCS_REF} --build-arg BUILD_DATE=${BUILD_DATE} --build-arg VERSION=${VERSION} .
-          docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-          docker push gdragon/throw-voice:${VERSION}
+          # docker build --quiet --cache-from gdragon/throw-voice:latest -t gdragon/throw-voice:${VERSION} --build-arg VCS_REF=${VCS_REF} --build-arg BUILD_DATE=${BUILD_DATE} --build-arg VERSION=${VERSION} .
+          # docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+          # docker push gdragon/throw-voice:${VERSION}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,9 @@
-# Java Maven CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-java/ for more details
-#
 version: 2
 jobs:
   build:
+    working_directory: ~/pawa
     docker:
-      # specify the version you desire here
       - image: circleci/openjdk:9-jdk
-
-     working_directory: ~/pawa
-
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,3 +66,6 @@ workflows:
       - upload-artifact:
           requires:
             - build
+          filters:
+            branches:
+             only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run: mvn integration-test
 
       - persist_to_workspace:
-          root: /tmp/workspace
+          root: /root/workspace
           paths:
             - target/site/jacoco/jacoco.xml
 
@@ -39,8 +39,8 @@ jobs:
       - image: circleci/openjdk:9-jdk
     steps:
         - attach_workspace:
-            at: /tmp/workspace
-        - run: bash <(curl -s https://codecov.io/bash) -s /tmp/workspace
+            at: /root/workspace
+        - run: bash <(curl -s https://codecov.io/bash) -s /root/workspace
 workflows:
   version: 2
   full_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # specify the version you desire here
       - image: circleci/openjdk:9-jdk
 
-     working_directory: ~/repo
+     working_directory: ~/pawa
 
     environment:
       # Customize the JVM maximum heap limit
@@ -21,17 +21,16 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "pom.xml" }}
+          - pawa-{{ checksum "pom.xml" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          - pawa-
 
       - run: mvn dependency:go-offline
 
       - save_cache:
           paths:
             - ~/.m2
-          key: v1-dependencies-{{ checksum "pom.xml" }}
+          key: pawa-{{ checksum "pom.xml" }}
 
       # run tests!
       - run: mvn integration-test
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,27 +54,29 @@ jobs:
       - checkout
       - run: |
           VCS_REF=$(git rev-parse --short HEAD)
-          [[ -v CIRCLE_TAG ]] && VERSION=${CIRCLE_TAG} || VERSION=1.2.0.${CIRCLE_BUILD_NUM}
+          [[ -v CIRCLE_TAG ]] && VERSION=${CIRCLE_TAG#"v"} || VERSION=1.2.0.${CIRCLE_BUILD_NUM}
           BUILD_DATE=$(date +%FT%T.%z)
-          echo ${VERSION}
-          # docker build --quiet --cache-from gdragon/throw-voice:latest -t gdragon/throw-voice:${VERSION} --build-arg VCS_REF=${VCS_REF} --build-arg BUILD_DATE=${BUILD_DATE} --build-arg VERSION=${VERSION} .
-          # docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-          # docker push gdragon/throw-voice:${VERSION}
+          docker build --quiet --cache-from gdragon/throw-voice:latest -t gdragon/throw-voice:${VERSION} --build-arg VCS_REF=${VCS_REF} --build-arg BUILD_DATE=${BUILD_DATE} --build-arg VERSION=${VERSION} .
+          docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+          docker push gdragon/throw-voice:${VERSION}
 
 workflows:
   version: 2
-#  build-with-coverage:
-#    jobs:
-#      - build
-#      - coverage:
-#          requires:
-#            - build
-#      - upload-artifact:
-#          requires:
-#            - build
-#          filters:
-#            branches:
-#              only: master
-  build-container-deploy:
+  build-with-coverage-and-docker-deploy:
     jobs:
-      - container
+      - build
+      - coverage:
+          requires:
+            - build
+      - upload-artifact:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - container:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,13 +54,27 @@ jobs:
       - checkout
       - run: |
           VCS_REF=$(git rev-parse --short HEAD)
-          VERSION=1.2.0.${CIRCLE_BUILD_NUM}
+          [[ -z "${CIRCLE_TAG}" ]] && VERSION=${CIRCLE_TAG} || VERSION=1.2.0.${CIRCLE_BUILD_NUM}
           BUILD_DATE=$(date +%FT%T.%z)
-          docker build --cache-from gdragon/throw-voice:latest -t gdragon/throw-voice:${VERSION} --build-arg VCS_REF=${VCS_REF} --build-arg BUILD_DATE=${BUILD_DATE} --build-arg VERSION=${VERSION} .
+          echo ${VERSION}
+          docker build --quiet --cache-from gdragon/throw-voice:latest -t gdragon/throw-voice:${VERSION} --build-arg VCS_REF=${VCS_REF} --build-arg BUILD_DATE=${BUILD_DATE} --build-arg VERSION=${VERSION} .
           docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
           docker push gdragon/throw-voice:${VERSION}
+
 workflows:
   version: 2
-  build-container:
+#  build-with-coverage:
+#    jobs:
+#      - build
+#      - coverage:
+#          requires:
+#            - build
+#      - upload-artifact:
+#          requires:
+#            - build
+#          filters:
+#            branches:
+#              only: master
+  build-container-deploy:
     jobs:
       - container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+# Java Maven CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-java/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:9-jdk
+
+     working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      MAVEN_OPTS: -Xmx3200m
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "pom.xml" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: mvn dependency:go-offline
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "pom.xml" }}
+
+      # run tests!
+      - run: mvn integration-test
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,12 @@
+defaults: &defafults
+  working_directory: ~/pawa
+  docker:
+    - image: circleci/openjdk:9-jdk
+
 version: 2
 jobs:
   build:
-    working_directory: ~/pawa
-    docker:
-      - image: circleci/openjdk:9-jdk
+    <<: *defafults
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
@@ -29,18 +32,16 @@ jobs:
       - run: mvn integration-test
 
       - persist_to_workspace:
-          root: /root/workspace
+          root: ./workspace
           paths:
             - target/site/jacoco/jacoco.xml
 
   coverage:
-    working_directory: ~/pawa
-    docker:
-      - image: circleci/openjdk:9-jdk
+    <<: *defafults
     steps:
         - attach_workspace:
-            at: /root/workspace
-        - run: bash <(curl -s https://codecov.io/bash) -s /root/workspace
+            at: ~/pawa/workspace
+        - run: bash <(curl -s https://codecov.io/bash) -s ~/pawa/workspace
 workflows:
   version: 2
   build-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - target/site
-
-      - store_artifacts:
-          path: target/throw-voice-*-release.zip
+            - target
 
   coverage:
     <<: *defaults
@@ -49,11 +46,25 @@ jobs:
             at: ~/pawa
         - run: bash <(curl -s https://codecov.io/bash) -s ~/pawa/target -X gcov
 
+  upload-artifact:
+    <<: *defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/pawa
+      - run: |
+          export `printf 'VERSION=${project.version}\n0\n' | mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate | grep '^VERSION'`
+      - store_artifacts:
+          path: target/throw-voice-${VERSION}-release.zip
+
 workflows:
   version: 2
   build-coverage:
     jobs:
       - build
       - coverage:
+          requires:
+            - build
+      - upload-artifact:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,9 @@ jobs:
         - run: bash <(curl -s https://codecov.io/bash) -s /root/workspace
 workflows:
   version: 2
-  full_build:
+  build-coverage:
     jobs:
       - build
-      - coverage
+      - coverage:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-defaults: &defafults
+defaults: &defaults
   working_directory: ~/pawa
   docker:
     - image: circleci/openjdk:9-jdk
@@ -6,7 +6,7 @@ defaults: &defafults
 version: 2
 jobs:
   build:
-    <<: *defafults
+    <<: *defaults
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
@@ -32,18 +32,20 @@ jobs:
       - run: mvn integration-test
 
       - persist_to_workspace:
-          root: target
+          root: .
           paths:
-            - site/jacoco/jacoco.xml
+            - target/site
 
   coverage:
-    <<: *defafults
+    <<: *defaults
     docker:
       - image: circleci/buildpack-deps:curl
     steps:
+        - checkout
         - attach_workspace:
-            at: ~/pawa/workspace
-        - run: bash <(curl -s https://codecov.io/bash) -s ~/pawa/workspace
+            at: ~/pawa
+        - run: bash <(curl -s https://codecov.io/bash) -s ~/pawa/target -X gcov
+
 workflows:
   version: 2
   build-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,15 +47,12 @@ jobs:
         - run: bash <(curl -s https://codecov.io/bash) -s ~/pawa/target -X gcov
 
   upload-artifact:
-    <<: *defaults
+    working_directory: ~/pawa
     steps:
-      - checkout
       - attach_workspace:
           at: ~/pawa
-      - run: |
-          export `printf 'VERSION=${project.version}\n0\n' | mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate | grep '^VERSION'`
       - store_artifacts:
-          path: target/throw-voice-${VERSION}-release.zip
+          path: target/throw-voice-1.2.0-SNAPSHOT-release.zip
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,17 +47,21 @@ jobs:
       - store_artifacts:
           path: target/throw-voice-1.2.0-SNAPSHOT-release.zip
 
+  container:
+    <<: *defaults
+    machine: true
+    steps:
+      - run: |
+          VCS_REF=$(git rev-parse --short HEAD)
+          VERSION=1.2.0-beta.${CIRCLE_BUILD_NUM}
+          BUILD_DATE=date +%FT%T.%z
+          echo ${VCS_REF}
+          echo ${VERSION}
+          echo ${BUILD_DATE}
+          # docker build -t gdragon/throw-voice:%VERSION% --build-arg VCS_REF=${VCS_REF} --build-arg BUILD_DATE=${BUILD_DATE} --build-arg VERSION=${VERSION} .
+
 workflows:
   version: 2
-  build-coverage:
+  build-container:
     jobs:
-      - build
-      - coverage:
-          requires:
-            - build
-      - upload-artifact:
-          requires:
-            - build
-          filters:
-            branches:
-             only: master
+      - container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
 
   upload-artifact:
     working_directory: ~/pawa
+    machine: true
     steps:
       - attach_workspace:
           at: ~/pawa

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,10 +54,11 @@ jobs:
       - checkout
       - run: |
           VCS_REF=$(git rev-parse --short HEAD)
-          VERSION=1.2.0-beta.${CIRCLE_BUILD_NUM}
+          VERSION=1.2.0.${CIRCLE_BUILD_NUM}
           BUILD_DATE=$(date +%FT%T.%z)
           docker build --cache-from gdragon/throw-voice:latest -t gdragon/throw-voice:${VERSION} --build-arg VCS_REF=${VCS_REF} --build-arg BUILD_DATE=${BUILD_DATE} --build-arg VERSION=${VERSION} .
-
+          docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+          docker push gdragon/throw-voice:${VERSION}
 workflows:
   version: 2
   build-container:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,3 +27,23 @@ jobs:
 
       # run tests!
       - run: mvn integration-test
+
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - target/site/jacoco/jacoco.xml
+
+  coverage:
+    working_directory: ~/pawa
+    docker:
+      - image: circleci/openjdk:9-jdk
+    steps:
+        - attach_workspace:
+            at: /tmp/workspace
+        - run: bash <(curl -s https://codecov.io/bash) -s /tmp/workspace
+workflows:
+  version: 2
+  full_build:
+    jobs:
+      - build
+      - coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,14 +51,12 @@ jobs:
     <<: *defaults
     machine: true
     steps:
+      - checkout
       - run: |
           VCS_REF=$(git rev-parse --short HEAD)
           VERSION=1.2.0-beta.${CIRCLE_BUILD_NUM}
-          BUILD_DATE=date +%FT%T.%z
-          echo ${VCS_REF}
-          echo ${VERSION}
-          echo ${BUILD_DATE}
-          # docker build -t gdragon/throw-voice:%VERSION% --build-arg VCS_REF=${VCS_REF} --build-arg BUILD_DATE=${BUILD_DATE} --build-arg VERSION=${VERSION} .
+          BUILD_DATE=$(date +%FT%T.%z)
+          docker build --cache-from gdragon/throw-voice:latest -t gdragon/throw-voice:${VERSION} --build-arg VCS_REF=${VCS_REF} --build-arg BUILD_DATE=${BUILD_DATE} --build-arg VERSION=${VERSION} .
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,9 @@ jobs:
       - run: mvn integration-test
 
       - persist_to_workspace:
-          root: ./workspace
+          root: target
           paths:
-            - target/site/jacoco/jacoco.xml
+            - site/jacoco/jacoco.xml
 
   coverage:
     <<: *defafults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,36 +1,28 @@
 defaults: &defaults
   working_directory: ~/pawa
-  docker:
-    - image: circleci/openjdk:9-jdk
 
 version: 2
 jobs:
   build:
     <<: *defaults
+    docker:
+        - image: circleci/openjdk:9-jdk
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m
-
     steps:
       - checkout
-
-      # Download and cache dependencies
       - restore_cache:
           keys:
           - pawa-{{ checksum "pom.xml" }}
           # fallback to using the latest cache if no exact match is found
           - pawa-
-
       - run: mvn dependency:go-offline
-
       - save_cache:
           paths:
             - ~/.m2
           key: pawa-{{ checksum "pom.xml" }}
-
-      # run tests!
       - run: mvn integration-test
-
       - persist_to_workspace:
           root: .
           paths:
@@ -47,7 +39,7 @@ jobs:
         - run: bash <(curl -s https://codecov.io/bash) -s ~/pawa/target -X gcov
 
   upload-artifact:
-    working_directory: ~/pawa
+    <<: *defaults
     machine: true
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ jobs:
           paths:
             - target/site
 
+      - store_artifacts:
+          path: target/throw-voice-*-release.zip
+
   coverage:
     <<: *defaults
     docker:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: java
-jdk:
-  - oraclejdk9
-after_success:
-- mvn coveralls:report

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 [![Build Status](https://travis-ci.org/guacamoledragon/throw-voice.svg?branch=master)](https://travis-ci.org/guacamoledragon/throw-voice)
 [![CircleCI](https://circleci.com/gh/guacamoledragon/throw-voice.svg?style=svg)](https://circleci.com/gh/guacamoledragon/throw-voice)
-[![Coverage Status](https://coveralls.io/repos/github/guacamoledragon/throw-voice/badge.svg)](https://coveralls.io/github/guacamoledragon/throw-voice)
+[![codecov](https://codecov.io/gh/guacamoledragon/throw-voice/branch/master/graph/badge.svg)](https://codecov.io/gh/guacamoledragon/throw-voice)
 [![Waffle.io - Columns and their card count](https://badge.waffle.io/guacamoledragon/throw-voice.svg?columns=all)](https://waffle.io/guacamoledragon/throw-voice)
 [![Docker Pulls](https://img.shields.io/docker/pulls/gdragon/throw-voice.svg)](https://hub.docker.com/r/gdragon/throw-voice/)
-[![](https://images.microbadger.com/badges/version/gdragon/throw-voice.svg)](https://microbadger.com/images/gdragon/throw-voice "Get your own version badge on microbadger.com")
+[![Get your own version badge on microbadger.com](https://images.microbadger.com/badges/version/gdragon/throw-voice.svg)](https://microbadger.com/images/gdragon/throw-voice)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fguacamoledragon%2Fthrow-voice.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fguacamoledragon%2Fthrow-voice?ref=badge_shield)
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
 </p>
 
 [![Build Status](https://travis-ci.org/guacamoledragon/throw-voice.svg?branch=master)](https://travis-ci.org/guacamoledragon/throw-voice)
+[![CircleCI](https://circleci.com/gh/guacamoledragon/throw-voice.svg?style=svg)](https://circleci.com/gh/guacamoledragon/throw-voice)
 [![Coverage Status](https://coveralls.io/repos/github/guacamoledragon/throw-voice/badge.svg)](https://coveralls.io/github/guacamoledragon/throw-voice)
 [![Waffle.io - Columns and their card count](https://badge.waffle.io/guacamoledragon/throw-voice.svg?columns=all)](https://waffle.io/guacamoledragon/throw-voice)
 [![Docker Pulls](https://img.shields.io/docker/pulls/gdragon/throw-voice.svg)](https://hub.docker.com/r/gdragon/throw-voice/)
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fguacamoledragon%2Fthrow-voice.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fguacamoledragon%2Fthrow-voice?ref=badge_shield)
 [![](https://images.microbadger.com/badges/version/gdragon/throw-voice.svg)](https://microbadger.com/images/gdragon/throw-voice "Get your own version badge on microbadger.com")
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fguacamoledragon%2Fthrow-voice.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fguacamoledragon%2Fthrow-voice?ref=badge_shield)
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/pom.xml
+++ b/pom.xml
@@ -415,33 +415,5 @@
         </plugins>
       </build>
     </profile>
-
-    <!--
-      I've become quite accustomed to developing with a REPL,
-      this is profile that adds Scala Maven Plugin so that I can
-      load a REPL with this pom's classpath.
-    -->
-    <profile>
-      <id>repl</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>net.alchim31.maven</groupId>
-            <artifactId>scala-maven-plugin</artifactId>
-            <version>3.2.1</version>
-            <configuration>
-              <fork>false</fork>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-      <dependencies>
-        <dependency>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-library</artifactId>
-          <version>2.11.8</version>
-        </dependency>
-      </dependencies>
-    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <jda.version>3.6.0_360</jda.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
-    <kotlin.version>1.2.40</kotlin.version>
+    <kotlin.version>1.2.41</kotlin.version>
     <main.class>tech.gdragon.App</main.class>
     <maven.compiler.source>1.9</maven.compiler.source>
     <maven.compiler.target>1.9</maven.compiler.target>
@@ -164,8 +164,8 @@
             </goals>
             <configuration>
               <sourceDirs>
-                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
-                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                <source>src/main/java</source>
+                <source>src/main/kotlin</source>
               </sourceDirs>
             </configuration>
           </execution>
@@ -177,8 +177,8 @@
             </goals>
             <configuration>
               <sourceDirs>
-                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
-                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                <sourceDir>src/test/kotlin</sourceDir>
+                <sourceDir>src/test/java</sourceDir>
               </sourceDirs>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -276,15 +276,6 @@
           <shortRevisionLength>7</shortRevisionLength>
         </configuration>
       </plugin>
-      <!--
-          You can run jacoco in the default profile with:
-          mvn jacoco:prepare-agent test jacoco:report
-      -->
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.9</version>
-      </plugin>
     </plugins>
   </build>
 
@@ -354,22 +345,30 @@
     </profile>
 
     <!--
-    This profile enables jacoco when unit tests are run.
-    You can run it with mvn -P jacoco test.
-    It also activates itself on Travis.
+    For the Travis profile:
+    - we want to be able to publish coverage report to coveralls.
     -->
     <profile>
-      <id>jacoco</id>
+      <id>ci</id>
       <activation>
         <property>
-          <name>env.TRAVIS</name>
+          <name>env.CI</name>
         </property>
       </activation>
       <build>
         <plugins>
+<!--          <plugin>
+            <groupId>org.eluder.coveralls</groupId>
+            <artifactId>coveralls-maven-plugin</artifactId>
+            <version>4.3.0</version>
+            <configuration>
+              <repoToken>VXG0CtzEZxQUi9U3NS9Zjo0LHRnGGQP22</repoToken>
+            </configuration>
+          </plugin>-->
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.7.9</version>
             <executions>
               <execution>
                 <id>prepare-agent</id>
@@ -386,31 +385,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <!--
-    For the Travis profile:
-    - we want to be able to publish coverage report to coveralls.
-    -->
-    <profile>
-      <id>travis</id>
-      <activation>
-        <property>
-          <name>env.TRAVIS</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eluder.coveralls</groupId>
-            <artifactId>coveralls-maven-plugin</artifactId>
-            <version>4.3.0</version>
-            <configuration>
-              <repoToken>VXG0CtzEZxQUi9U3NS9Zjo0LHRnGGQP22</repoToken>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <jda.version>3.6.0_356</jda.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
-    <kotlin.version>1.2.31</kotlin.version>
+    <kotlin.version>1.2.40</kotlin.version>
     <main.class>tech.gdragon.App</main.class>
     <maven.compiler.source>1.9</maven.compiler.source>
     <maven.compiler.target>1.9</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </scm>
 
   <properties>
-    <jda.version>3.6.0_356</jda.version>
+    <jda.version>3.6.0_360</jda.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     <kotlin.version>1.2.40</kotlin.version>
     <main.class>tech.gdragon.App</main.class>

--- a/pom.xml
+++ b/pom.xml
@@ -344,10 +344,6 @@
       </build>
     </profile>
 
-    <!--
-    For the Travis profile:
-    - we want to be able to publish coverage report to coveralls.
-    -->
     <profile>
       <id>ci</id>
       <activation>
@@ -357,14 +353,6 @@
       </activation>
       <build>
         <plugins>
-<!--          <plugin>
-            <groupId>org.eluder.coveralls</groupId>
-            <artifactId>coveralls-maven-plugin</artifactId>
-            <version>4.3.0</version>
-            <configuration>
-              <repoToken>VXG0CtzEZxQUi9U3NS9Zjo0LHRnGGQP22</repoToken>
-            </configuration>
-          </plugin>-->
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>

--- a/src/test/kotlin/AppTest.kt
+++ b/src/test/kotlin/AppTest.kt
@@ -1,0 +1,11 @@
+package tech.gdragon
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class AppTest {
+  @Test
+  fun testAssert() : Unit {
+    assertEquals("hello", "hello")
+  }
+}


### PR DESCRIPTION
This PR primarily fixes CI more than improving it, TravisCI would only build the source but wouldn't do much besides that.

The major changes in this branch are:

* Remove TravisCI
* Clean up `pom.xml` and remove anything related to Travis
* Switch to https://codecov.io from https://coveralls.io
* CI will generate build artifacts for the standalone deploy as well as for Docker

There's improvements to be made still but this is a much better way to do CI, before nothing was really getting tested.

Closes #52 