### PR TITLE
AutoSave when bot leaves after AFK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>tech.gdragon</groupId>
   <artifactId>throw-voice</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.0-branch.74</version>
   <scm>
     <connection>scm:git:https://github.com/guacamoledragon/throw-voice.git</connection>
     <url>https://github.com/guacamoledragon/throw-voice</url>

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -178,6 +178,13 @@ object BotUtils {
     return null
   }
 
+  fun autoSave(discordGuild: DiscordGuild): Boolean {
+    return transaction {
+      val guild = Guild.findById(discordGuild.idLong)
+      guild?.settings?.autoSave ?: false
+    }
+  }
+
   @JvmStatic
   fun leaveVoiceChannel(voiceChannel: VoiceChannel?) {
     val guild = voiceChannel?.guild

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -91,6 +91,7 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
       BotUtils.sendMessage(defaultChannel, "_:sleeping: No audio detected in the last 2 minutes, leaving <#${voiceChannel.id}>._")
 
       thread(start = true) {
+        if(BotUtils.autoSave(voiceChannel.guild)) saveRecording(voiceChannel, voiceChannel.guild.getTextChannelById(defaultChannel.idLong))
         BotUtils.leaveVoiceChannel(voiceChannel)
       }
     }

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -144,7 +144,7 @@ class EventListener : ListenerAdapter() {
   override fun onReady(event: ReadyEvent) {
     event
       .jda
-      .presence.game = object : Game("1.2.0-SNAPSHOT | https://www.pawabot.site", "https://www.pawabot.site", Game.GameType.DEFAULT) {
+      .presence.game = object : Game("1.2.0-branch.74 | https://www.pawabot.site", "https://www.pawabot.site", Game.GameType.DEFAULT) {
 
     }
 
@@ -160,7 +160,7 @@ class EventListener : ListenerAdapter() {
       var dir = Paths.get("/var/www/html/")
       if (Files.notExists(dir)) {
         val dataDirectory = System.getenv("DATA_DIR")
-        dir = Files.createDirectories(Paths.get(dataDirectory + "/recordings/"))
+        dir = Files.createDirectories(Paths.get("$dataDirectory/recordings/"))
         logger.info("Creating: " + dir.toString())
       }
 


### PR DESCRIPTION
The `autosave` command would only apply when the user would tell the bot to leave the channel, since `autoleave` isn't implemented correctly yet, this PR is a patch to make `autosave` go into effect when the bot decides to leave after everyone in the room is AFK.

The super big caveat to this is that there will be a long 2 minute trailing moment of silence. Could probably get rid of this if I knew the actual duration of the recording, but at this moment that's not being tracked.

Closes #74 

There's a chance I may need to roll this PR back if 💩 hits the fan.