### PR TITLE
Use save location

### DIFF
--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -144,7 +144,7 @@ class EventListener : ListenerAdapter() {
   override fun onReady(event: ReadyEvent) {
     event
       .jda
-      .presence.game = object : Game("1.2.0-branch.74 | https://www.pawabot.site", "https://www.pawabot.site", Game.GameType.DEFAULT) {
+      .presence.game = object : Game("1.2.0-beta.76 | https://www.pawa.im", "https://www.pawa.im", Game.GameType.DEFAULT) {
 
     }
 


### PR DESCRIPTION
The `saveLocation` command had little to no effect, nothing was using this. It has now been hooked up in places where it makes sense.

Basically, if the bot tries to join a voice channel, it needs to alert a text channel, it'll first try to write to the channel from where it got a message from if it can't it'll write to the default channel. If it cannot write to that either then it wont even try to record.

I bet some edge case was missed but this is the beginnings of that effort.