### PR TITLE
Save location fix, won't set to channels that bot cannot chat in

### DIFF
--- a/src/main/kotlin/tech/gdragon/commands/settings/SaveLocation.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/SaveLocation.kt
@@ -19,22 +19,29 @@ class SaveLocation : Command {
       val message =
         guild?.settings?.let {
           if (args.isEmpty()) {
-            it.defaultTextChannel = event.channel.idLong
-
-            "Now defaulting to the ${event.channel.name} text channel."
+            if (event.channel.canTalk()) {
+              it.defaultTextChannel = event.channel.idLong
+              ":file_folder: _All messages will default to channel **<#${event.channel.id}>**._"
+            } else {
+              ":no_entry_sign: _Cannot send messages in **<#${event.channel.id}>**, please configure permissions and try again._"
+            }
           } else {
             val channelName = if (args.first().startsWith("#")) args.first().substring(1) else args.first()
-
             val channels = event.guild.getTextChannelsByName(channelName, true)
 
             if (channels.isEmpty()) {
-              "Cannot find $channelName!"
+              ":no_entry_sign: _Cannot find text channel **${args.first()}**!_"
             } else {
-              it.defaultTextChannel = channels.first().idLong
-              "Now defaulting to the ${channels.first().name} text channel."
+              val channel = channels.first()
+              if (channel.canTalk()) {
+                it.defaultTextChannel = channel.idLong
+                ":file_folder: _All messages will default to channel **<#${channel.id}>**._"
+              } else {
+                ":no_entry_sign: _Cannot send messages in **<#${channel.id}>**, please configure permissions and try again._"
+              }
             }
           }
-        } ?: "Could not set default save location."
+        } ?: ":no_entry_sign: _Could not set default save location._"
 
       BotUtils.sendMessage(event.channel, message)
     }
@@ -42,5 +49,5 @@ class SaveLocation : Command {
 
   override fun usage(prefix: String): String = "${prefix}saveLocation | ${prefix}saveLocation [text channel name]"
 
-  override fun description(): String = "Sets the text channel of message or the text channel specified as the default location to send files."
+  override fun description(): String = "Set default channel to send messages in, including the link to the voice recording"
 }

--- a/src/main/kotlin/tech/gdragon/commands/settings/SaveLocation.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/SaveLocation.kt
@@ -1,13 +1,24 @@
 package tech.gdragon.commands.settings
 
+import net.dv8tion.jda.core.entities.TextChannel
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
 import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
+import tech.gdragon.db.dao.Settings
 
 class SaveLocation : Command {
+  private fun setSaveLocation(settings: Settings, channel: TextChannel): String {
+    return if (channel.canTalk()) {
+      settings.defaultTextChannel = channel.idLong
+      ":file_folder: _All messages will default to channel **<#${channel.id}>**._"
+    } else {
+      ":no_entry_sign: _Cannot send messages in **<#${channel.id}>**, please configure permissions and try again._"
+    }
+  }
+
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
     require(args.size in 0..1) {
       throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
@@ -19,12 +30,7 @@ class SaveLocation : Command {
       val message =
         guild?.settings?.let {
           if (args.isEmpty()) {
-            if (event.channel.canTalk()) {
-              it.defaultTextChannel = event.channel.idLong
-              ":file_folder: _All messages will default to channel **<#${event.channel.id}>**._"
-            } else {
-              ":no_entry_sign: _Cannot send messages in **<#${event.channel.id}>**, please configure permissions and try again._"
-            }
+            setSaveLocation(it, event.channel)
           } else {
             val channelName = if (args.first().startsWith("#")) args.first().substring(1) else args.first()
             val channels = event.guild.getTextChannelsByName(channelName, true)
@@ -32,13 +38,7 @@ class SaveLocation : Command {
             if (channels.isEmpty()) {
               ":no_entry_sign: _Cannot find text channel **${args.first()}**!_"
             } else {
-              val channel = channels.first()
-              if (channel.canTalk()) {
-                it.defaultTextChannel = channel.idLong
-                ":file_folder: _All messages will default to channel **<#${channel.id}>**._"
-              } else {
-                ":no_entry_sign: _Cannot send messages in **<#${channel.id}>**, please configure permissions and try again._"
-              }
+              setSaveLocation(it, channels.first())
             }
           }
         } ?: ":no_entry_sign: _Could not set default save location._"


### PR DESCRIPTION
As the title says, the previous PR(#77) started using the `saveLocation` value but would allow the user to select a channel that the bot could not write to, thus making the whole thing useless.

I've added some guards as well as modified the text responses to closely resemble what the other commands do. I'm changing this as I go, but this is progress towards #44.

The `SaveLocation#action` function is still a bit sloppy. I just really wanted to get this out there, I'll try to revisit.

Closes #76
Closes #56, fixing this command basically forced me to enable default channel, so two in one ;)