### PR TITLE
Remove Alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@
 
 |                            Command                            |                                                                  Description                                                                   |
 |:--------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
-| `!alerts [on \| off]`                                         | Turns on/off direct message alerts for when you are being recorded in a voice channel (on by default)                                          |
 | `!alias [command name] [new command alias]`                   | Creates an alias, or alternate name, to a command for customization.                                                                           |
 | `!autojoin [Voice Channel name \| 'all'] [number \| 'off']`   | Sets the number of players for the bot to auto-join a voice channel, or disables auto-joining. 'all' will apply number to all voice channels.  |
 | `!autoleave [Voice Channel name \| 'all'] [number]`           | Sets the number of players for the bot to auto-leave a voice channel, or disables auto-leaving. 'all' will apply number to all voice channels. |

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -23,6 +23,7 @@ object BotUtils {
   /**
    * Send a DM to anyone in the voiceChannel unless they are in the blacklist
    */
+  @Deprecated("Alerts no longer supported, will be removed on next version.", ReplaceWith("BotUtils.sendMessage(null, alertMessage)", "tech.gdragon"), DeprecationLevel.ERROR)
   fun alert(channel: VoiceChannel, alertMessage: String) {
     transaction {
       val guild = Guild.findById(channel.guild.idLong)

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -10,11 +10,8 @@ import net.dv8tion.jda.core.exceptions.InsufficientPermissionException
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.listener.CombinedAudioRecorderHandler
-import tech.gdragon.listener.SilenceAudioSendHandler
 import java.awt.Color
 import java.time.OffsetDateTime
-import java.util.*
-import kotlin.concurrent.schedule
 import net.dv8tion.jda.core.entities.Guild as DiscordGuild
 
 object BotUtils {
@@ -180,14 +177,8 @@ object BotUtils {
           ?.toDouble()
           ?: 1.0
 
-        val audioSendHandler = SilenceAudioSendHandler()
-        // Only send 5 seconds of audio at the beginning of the recording see: https://github.com/DV8FromTheWorld/JDA/issues/653
-        Timer().schedule(5 * 1000) {
-          audioSendHandler.canProvide = false
-        }
         audioManager?.setReceivingHandler(CombinedAudioRecorderHandler(volume, channel, saveLocation))
-        audioManager?.sendingHandler = audioSendHandler
-        alert(channel, "Your audio is now being recorded in **<#${channel.id}>** on **${channel.guild.name}**.")
+        sendMessage(saveLocation, ":red_circle: **Audio is being recorded on <#${channel.id}>**")
       }
     }
 

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -117,21 +117,21 @@ object BotUtils {
    */
   fun defaultTextChannel(discordGuild: DiscordGuild): MessageChannel? {
     return transaction {
-        val guild = Guild.findById(discordGuild.idLong)
-        val defaultChannelId = guild?.settings?.defaultTextChannel
-        if (defaultChannelId == null) {
-          (discordGuild.textChannels.find { it.canTalk() })?.also {
-            val prefix = guild?.settings?.prefix
-            val msg = """
+      val guild = Guild.findById(discordGuild.idLong)
+      val defaultChannelId = guild?.settings?.defaultTextChannel
+      if (defaultChannelId == null) {
+        (discordGuild.textChannels.find { it.canTalk() })?.also {
+          val prefix = guild?.settings?.prefix
+          val msg = """
               :warning: _The save location hasn't been set, please use `${prefix}saveLocation` to set.
               This channel will be used in the meantime. For more information use `${prefix}help`._
             """.trimIndent()
-            sendMessage(it, msg)
-          }
-        } else {
-          discordGuild.getTextChannelById(defaultChannelId)
+          sendMessage(it, msg)
         }
+      } else {
+        discordGuild.getTextChannelById(defaultChannelId)
       }
+    }
   }
 
   fun isSelfBot(jda: JDA, user: User): Boolean {

--- a/src/main/kotlin/tech/gdragon/TestApp.kt
+++ b/src/main/kotlin/tech/gdragon/TestApp.kt
@@ -81,7 +81,7 @@ fun testAlerts() {
     .addEventListener(object : ListenerAdapter() {
       override fun onGuildVoiceJoin(event: GuildVoiceJoinEvent) {
         println("Sending alerts to users that joined ${event.channelJoined}.")
-        BotUtils.alert(event.channelJoined, "")
+        BotUtils.sendMessage(null, "")
         super.onGuildVoiceJoin(event)
       }
     })

--- a/src/main/kotlin/tech/gdragon/commands/misc/Join.kt
+++ b/src/main/kotlin/tech/gdragon/commands/misc/Join.kt
@@ -18,7 +18,7 @@ class Join : Command {
       val guild = Guild.findById(event.guild.idLong)
 
       val voiceChannel = event.member.voiceState.channel
-      val message =
+      val message: String? =
         if (voiceChannel == null) {
           ":no_entry_sign: _Please join a voice channel before using this command._"
         } else {
@@ -26,7 +26,7 @@ class Join : Command {
           if (connectedChannel != null && connectedChannel.members.contains(event.member)) {
             ":no_entry_sign: _I am already in **<#${connectedChannel.id}>**._"
           } else {
-
+            // This is where the happy path logic begins
             if (event.guild.audioManager.isConnected) {
               guild?.settings?.let {
                 if (it.autoSave) {
@@ -37,9 +37,13 @@ class Join : Command {
               }
             }
 
+            // We need to give something to the onError handler because sometimes life doesn't do what we want
             BotUtils.joinVoiceChannel(voiceChannel, event.channel, true) { ex ->
-              ":no_entry_sign: _Cannot join **<#${event.channel.id}>**, need permission:_ ```${ex.permission}```"
+              val errorMessage = ":no_entry_sign: _Cannot join **<#${event.channel.id}>**, need permission:_ ```${ex.permission}```"
+              BotUtils.sendMessage(event.channel, errorMessage)
             }
+
+            null // TODO: This is weird, but the problem is probably with the way the logic is structured
           }
         }
 

--- a/src/main/kotlin/tech/gdragon/commands/misc/Join.kt
+++ b/src/main/kotlin/tech/gdragon/commands/misc/Join.kt
@@ -39,11 +39,13 @@ class Join : Command {
 
             BotUtils.joinVoiceChannel(voiceChannel, event.channel, true) { ex ->
               ":no_entry_sign: _Cannot join **<#${event.channel.id}>**, need permission:_ ```${ex.permission}```"
-            } ?: ":red_circle: **Recording on <#${voiceChannel.id}>**"
+            }
           }
         }
 
-      BotUtils.sendMessage(event.channel, message)
+      message?.let {
+        BotUtils.sendMessage(event.channel, it)
+      }
     }
   }
 

--- a/src/main/kotlin/tech/gdragon/commands/settings/Alerts.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/Alerts.kt
@@ -1,11 +1,9 @@
 package tech.gdragon.commands.settings
 
-import mu.KotlinLogging
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
-import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.db.dao.User
 
@@ -21,40 +19,11 @@ fun configureAlerts(userId: String, guildId: Long, enable: Boolean) {
 }
 
 class Alerts : Command {
-  private val logger = KotlinLogging.logger {}
 
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
-    val guildId = event.guild.idLong
-    val channel = event.channel
-
-    if (args.size == 1) {
-      val author = event.author
-
-      val alert = { enable: Boolean -> configureAlerts(author.id, guildId, enable) }
-      val message =
-        when (args.first()) {
-          "off" -> {
-            alert(false)
-            logger.info {
-              "${event.guild.name}#${event.channel.name}: Disable alerts for ${author.id}"
-            }
-            ":bangbang: _Alerts now **off**_"
-          }
-          "on" -> {
-            alert(true)
-            logger.info {
-              "${event.guild.name}#${event.channel.name}: Enable alerts for ${author.id}"
-            }
-            ":bangbang: _Alerts now **on**_"
-          }
-          else -> {
-            throw InvalidCommand(::usage, "Invalid argument: ${args.first()}")
-          }
-        }
-      BotUtils.sendMessage(channel, message)
-    } else {
-      throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
-    }
+    val botId = event.jda.selfUser.id
+    val message = ":no_entry_sign: _<@$botId> will no longer send alerts, this command will be removed in the next major release._"
+    BotUtils.sendMessage(event.channel, message)
   }
 
   override fun usage(prefix: String): String = "${prefix}alerts [on | off]"

--- a/src/main/kotlin/tech/gdragon/commands/settings/Alerts.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/Alerts.kt
@@ -1,28 +1,14 @@
 package tech.gdragon.commands.settings
 
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
-import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
-import tech.gdragon.db.dao.Guild
-import tech.gdragon.db.dao.User
-
-fun configureAlerts(userId: String, guildId: Long, enable: Boolean) {
-  transaction {
-    val settings = Guild.findById(guildId)?.settings!!
-    val user = User.findOrCreate(userId, settings)
-
-    if (enable) {
-      user.delete()
-    }
-  }
-}
 
 class Alerts : Command {
 
   override fun action(args: Array<String>, event: GuildMessageReceivedEvent) {
     val botId = event.jda.selfUser.id
-    val message = ":no_entry_sign: _<@$botId> will no longer send alerts, this command will be removed in the next major release._"
+    val message = ":no_entry_sign: _<@$botId> will no longer send alerts, this command will be removed in the next release._"
     BotUtils.sendMessage(event.channel, message)
   }
 

--- a/src/main/kotlin/tech/gdragon/commands/settings/SaveLocation.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/SaveLocation.kt
@@ -13,9 +13,9 @@ class SaveLocation : Command {
   private fun setSaveLocation(settings: Settings, channel: TextChannel): String {
     return if (channel.canTalk()) {
       settings.defaultTextChannel = channel.idLong
-      ":file_folder: _All messages will default to channel **<#${channel.id}>**._"
+      ":file_folder: _All messages will default to channel **${channel.asMention}**._"
     } else {
-      ":no_entry_sign: _Cannot send messages in **<#${channel.id}>**, please configure permissions and try again._"
+      ":no_entry_sign: _Cannot send messages in **${channel.asMention}**, please configure permissions and try again._"
     }
   }
 

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -277,25 +277,3 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
 
   override fun handleUserAudio(userAudio: UserAudio?) = TODO("Not implemented.")
 }
-
-class SilenceAudioSendHandler: AudioSendHandler {
-  private val logger = KotlinLogging.logger {  }
-  var canProvide = true
-    set(value) {
-      logger.debug { "canProvide toggling from $canProvide to $value" }
-      field = value
-    }
-
-  override fun provide20MsAudio(): ByteArray {
-    val silence = arrayOf(0xF8.toByte(), 0xFF.toByte(), 0xFE.toByte())
-    return silence.toByteArray()
-  }
-
-  override fun canProvide(): Boolean {
-    return canProvide
-  }
-
-  override fun isOpus(): Boolean {
-    return true
-  }
-}

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -53,12 +53,7 @@ class EventListener : ListenerAdapter() {
       return
     }
 
-    val errorMessage = BotUtils.autoJoin(event.guild, event.channelJoined) { ex ->
-      """|:no_entry_sign: _Cannot join **<#${event.channelJoined.id}>** on Guild **${event.guild.name}**,
-         |need permission:_ ```${ex.permission}```
-         |""".trimMargin()
-    }
-    errorMessage?.let { /*BotUtils.alert(event.channelJoined, it)*/ }
+    BotUtils.autoJoin(event.guild, event.channelJoined)
   }
 
   override fun onGuildVoiceLeave(event: GuildVoiceLeaveEvent) {
@@ -75,12 +70,7 @@ class EventListener : ListenerAdapter() {
       return
     }
 
-    val errorMessage = BotUtils.autoJoin(event.guild, event.channelJoined) { ex ->
-      """|:no_entry_sign: _Cannot join **<#${event.channelJoined.id}>** on Guild **${event.guild.name}**,
-         |need permission:_ ```${ex.permission}```
-         |""".trimMargin()
-    }
-    errorMessage?.let { /*BotUtils.alert(event.channelJoined, it)*/ }
+    BotUtils.autoJoin(event.guild, event.channelJoined)
   }
 
   override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -58,7 +58,7 @@ class EventListener : ListenerAdapter() {
          |need permission:_ ```${ex.permission}```
          |""".trimMargin()
     }
-    errorMessage?.let { BotUtils.alert(event.channelJoined, it) }
+    errorMessage?.let { /*BotUtils.alert(event.channelJoined, it)*/ }
   }
 
   override fun onGuildVoiceLeave(event: GuildVoiceLeaveEvent) {
@@ -80,7 +80,7 @@ class EventListener : ListenerAdapter() {
          |need permission:_ ```${ex.permission}```
          |""".trimMargin()
     }
-    errorMessage?.let { BotUtils.alert(event.channelJoined, it) }
+    errorMessage?.let { /*BotUtils.alert(event.channelJoined, it)*/ }
   }
 
   override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -15,7 +15,6 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import tech.gdragon.BotUtils
 import tech.gdragon.commands.CommandHandler
 import tech.gdragon.commands.InvalidCommand
-import tech.gdragon.commands.settings.configureAlerts
 import tech.gdragon.db.dao.Guild
 import java.io.IOException
 import java.nio.file.Files
@@ -100,34 +99,15 @@ class EventListener : ListenerAdapter() {
   }
 
   override fun onPrivateMessageReceived(event: PrivateMessageReceivedEvent) {
-    if (event.author == null || event.author.isBot)
-      return
+    if (event.author.isBot.not()) {
+      val message = """
+        For more information on ${event.jda.selfUser.asMention}, please visit https://www.pawa.im.
+      """.trimIndent()
 
-    val message = event.message.contentDisplay
-
-    if (message.startsWith("!alerts")) {
-      val userId = event.author.id
-
-      event.jda.guilds
-        .filter { it.isMember(event.author) }
-        .forEach {
-          val guildId = it.idLong
-          val alert = { enable: Boolean -> configureAlerts(userId, guildId, enable) }
-
-          when {
-            message.endsWith("off") -> {
-              alert(false)
-              event.channel.sendMessage("Alerts now off for guild `${it.name}`, message `!alerts on` to re-enable.").queue()
-            }
-            message.endsWith("on") -> {
-              alert(true)
-              event.channel.sendMessage("Alerts now on for guild `${it.name}`, message `!alerts off` to disable.").queue()
-            }
-            else -> event.channel.sendMessage("!alerts [on | off]").queue()
-          }
-        }
-    } else {
-      event.channel.sendMessage("The only DM command supported is `!alerts`.").queue()
+      event
+        .channel
+        .sendMessage(message)
+        .queue()
     }
   }
 


### PR DESCRIPTION
From multiple users I got feedback saying that alerts are kind of annoying, and most of them wanted to disable them from the server level.

Additionally, these are kind of hard to maintain because I would have to keep user specific settings and make sure they were all taking, honestly it was kind of a mess.

The `alerts` command is now disabled and no longer will the bot alert users, it'll still post a message to the `saveLocation` but it wont pester users with DMs.

As a follow up to this, I'll need to ensure that the bot's nick contains something saying that it's recording. I'll probably prepend(#80) the bot's name with `[REC]` just to make things simple. 

Fixes #79 
Fixes #71 