### PR TITLE
Prefix bot with [REC] if it's recording

### DIFF
--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -5,6 +5,7 @@ import net.dv8tion.jda.core.entities.Game
 import net.dv8tion.jda.core.events.ReadyEvent
 import net.dv8tion.jda.core.events.guild.GuildJoinEvent
 import net.dv8tion.jda.core.events.guild.GuildLeaveEvent
+import net.dv8tion.jda.core.events.guild.member.GuildMemberNickChangeEvent
 import net.dv8tion.jda.core.events.guild.voice.GuildVoiceJoinEvent
 import net.dv8tion.jda.core.events.guild.voice.GuildVoiceLeaveEvent
 import net.dv8tion.jda.core.events.guild.voice.GuildVoiceMoveEvent
@@ -108,6 +109,21 @@ class EventListener : ListenerAdapter() {
         .channel
         .sendMessage(message)
         .queue()
+    }
+  }
+
+  /**
+   * Always add recording prefix when recording and if possible.
+   */
+  override fun onGuildMemberNickChange(event: GuildMemberNickChangeEvent) {
+    if (BotUtils.isSelfBot(event.jda, event.user)) {
+      if(event.guild.audioManager.isConnected) {
+        logger.debug {
+          "${event.guild}#: Attempting to change nickname from ${event.prevNick} -> ${event.newNick}"
+        }
+
+        BotUtils.recordingStatus(event.member, true)
+      }
     }
   }
 


### PR DESCRIPTION
Alerts were removed cause they were annoying but I'd still like a way to let the users know that a recording is being in place.

Adding a prefix should alleviate some of the issues with not having alerts anymore.

Fixes #80 