### PR TITLE
Accep commands if user is a Bot

### DIFF
--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -75,7 +75,7 @@ class EventListener : ListenerAdapter() {
   }
 
   override fun onGuildMessageReceived(event: GuildMessageReceivedEvent) {
-    if (event.member == null || event.member.user == null || event.member.user.isBot)
+    if (event.member == null || event.member.user == null)
       return
 
     val guildId = event.guild.idLong


### PR DESCRIPTION
Bot would ignore text coming from a bot, this was done as an optimization but it has been requested that this is enabled.

Will accept commands from Bots until this becomes a problem.

Closes #87 