### PR TITLE
Add Metabase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM maven:3.5-jdk-9-slim as builder
+FROM maven:3.6-jdk-11 as builder
 WORKDIR /app
 COPY . /app
 
-RUN apt-get update && apt-get install -y \
-  git \
- && mvn package \
- && rm -rf /var/lib/apt/lists/*
+VOLUME /root/.m2
 
-FROM openjdk:9-jre-slim
+# Source: https://git.mikael.io/mikaelhg/broken-docker-jdk9-cacerts#tldr-workaround
+RUN /usr/bin/printf '\xfe\xed\xfe\xed\x00\x00\x00\x02\x00\x00\x00\x00\xe2\x68\x6e\x45\xfb\x43\xdf\xa4\xd9\x92\xdd\x41\xce\xb6\xb2\x1c\x63\x30\xd7\x92' > /etc/ssl/certs/java/cacerts \
+ && /var/lib/dpkg/info/ca-certificates-java.postinst configure \
+ && mvn package
+
+FROM openjdk:11-jre-slim
 MAINTAINER Jose V. Trigueros <jose@gdragon.tech>
 
 ARG BUILD_DATE
@@ -22,6 +24,10 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vendor="Guacamole Dragon, LLC" \
       org.label-schema.version=$VERSION \
       org.label-schema.schema-version="1.0"
+
+# Source: https://git.mikael.io/mikaelhg/broken-docker-jdk9-cacerts#tldr-workaround
+RUN /usr/bin/printf '\xfe\xed\xfe\xed\x00\x00\x00\x02\x00\x00\x00\x00\xe2\x68\x6e\x45\xfb\x43\xdf\xa4\xd9\x92\xdd\x41\xce\xb6\xb2\x1c\x63\x30\xd7\x92' > /etc/ssl/certs/java/cacerts \
+ && /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 ENV APP_DIR /app
 ENV DATA_DIR $APP_DIR/data

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG VERSION
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.name="throw-voice" \
       org.label-schema.description="A voice channel recording bot for Discord." \
-      org.label-schema.url="https://www.pawabot.site" \
+      org.label-schema.url="https://www.pawa.im" \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url="https://github.com/guacamoledragon/throw-voice" \
       org.label-schema.vendor="Guacamole Dragon, LLC" \
@@ -40,7 +40,7 @@ WORKDIR $APP_DIR
 COPY --from=builder /app/target/throw-voice-*-release.zip /tmp/throw-voice-release.zip
 RUN unzip -d $APP_DIR /tmp/throw-voice-release.zip
 
-ADD https://cdn.rawgit.com/fabric8io-images/run-java-sh/v1.2.0/fish-pepper/run-java-sh/fp-files/run-java.sh $APP_DIR
+ADD https://cdn.rawgit.com/fabric8io-images/run-java-sh/v1.2.2/fish-pepper/run-java-sh/fp-files/run-java.sh $APP_DIR
 
 VOLUME $DATA_DIR
 

--- a/Dockerfile.metabase
+++ b/Dockerfile.metabase
@@ -2,6 +2,10 @@ FROM openjdk:11-jre-slim
 
 ENV VERSION 0.31.2
 
+# Source: https://git.mikael.io/mikaelhg/broken-docker-jdk9-cacerts#tldr-workaround
+RUN /usr/bin/printf '\xfe\xed\xfe\xed\x00\x00\x00\x02\x00\x00\x00\x00\xe2\x68\x6e\x45\xfb\x43\xdf\xa4\xd9\x92\xdd\x41\xce\xb6\xb2\x1c\x63\x30\xd7\x92' > /etc/ssl/certs/java/cacerts \
+ && /var/lib/dpkg/info/ca-certificates-java.postinst configure
+
 ADD http://downloads.metabase.com/v$VERSION/metabase.jar /opt/metabase.jar
 
 CMD ["java", "-jar", "/opt/metabase.jar"]

--- a/Dockerfile.metabase
+++ b/Dockerfile.metabase
@@ -1,0 +1,7 @@
+FROM openjdk:11-jre-slim
+
+ENV VERSION 0.31.2
+
+ADD http://downloads.metabase.com/v$VERSION/metabase.jar /opt/metabase.jar
+
+CMD ["java", "-jar", "/opt/metabase.jar"]

--- a/Dockerfile.metabase
+++ b/Dockerfile.metabase
@@ -1,11 +1,10 @@
-FROM openjdk:11-jre-slim
+FROM openjdk:8-jre-slim
 
 ENV VERSION 0.31.2
 
-# Source: https://git.mikael.io/mikaelhg/broken-docker-jdk9-cacerts#tldr-workaround
-RUN /usr/bin/printf '\xfe\xed\xfe\xed\x00\x00\x00\x02\x00\x00\x00\x00\xe2\x68\x6e\x45\xfb\x43\xdf\xa4\xd9\x92\xdd\x41\xce\xb6\xb2\x1c\x63\x30\xd7\x92' > /etc/ssl/certs/java/cacerts \
- && /var/lib/dpkg/info/ca-certificates-java.postinst configure
+WORKDIR /app
 
-ADD http://downloads.metabase.com/v$VERSION/metabase.jar /opt/metabase.jar
+ADD https://raw.githubusercontent.com/metabase/metabase/v$VERSION/bin/start /app/bin/
+ADD http://downloads.metabase.com/v$VERSION/metabase.jar /app/target/uberjar/
 
-CMD ["java", "-jar", "/opt/metabase.jar"]
+CMD ["bash", "/app/bin/start"]

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -22,6 +22,10 @@ http {
       server data:3000;
   }
 
+  upstream portainer {
+      server portainer:9000;
+  }
+
   server {
     listen       80;
     server_name  ${BOT_HOST};

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -19,7 +19,7 @@ http {
   #gzip  on;
 
   upstream data {
-      server data:8001;
+      server data:3000;
   }
 
   server {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,11 @@
-version: '3'
+version: '3.4'
+
+x-logging: &logging
+  driver: json-file
+  options:
+    max-size: 100m
+    max-file: '5'
+
 services:
   bot:
     image: gdragon/throw-voice:${VERSION}
@@ -7,36 +14,34 @@ services:
       - ${ENV:-sample}-bot.env
       - ${ENV:-sample}-rollbar.env
     environment:
-      - JAVA_OPTIONS=--add-modules java.xml.bind
       - TZ=America/Los_Angeles
       - VERSION=${VERSION}
     volumes:
       - ./data:/app/data
     restart: on-failure:5
     logging:
-      driver: json-file
-      options:
-        max-size: 100m
-        max-file: '5'
+      <<: *logging
   portainer:
     image: portainer/portainer:latest
     command: -H unix:///var/run/docker.sock
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - portainer_data:/data
+    logging:
+      <<: *logging
   data:
-    image: datasetteproject/datasette:0.25.1
-    command: datasette -p 8001 -h 0.0.0.0 -m /mnt/metadata.json /mnt/settings.db
+    build:
+      context: .
+      dockerfile: Dockerfile.metabase
+    image: metabase/metabase:v0.31.2-custom
     environment:
       - TZ=America/Los_Angeles
+      - MB_DB_FILE=/tmp/metabase.db
     volumes:
-      - ./data/settings.db:/mnt/settings.db:ro
-      - ${CONF:-./}metadata.json:/mnt/metadata.json
+      - ./data/metabase:/tmp
+      - ./data/settings.db:/opt/bot.db
     logging:
-      driver: json-file
-      options:
-        max-size: 100m
-        max-file: '5'
+      <<: *logging
   nginx:
     image: nginx:1.15-alpine
     command: /bin/sh -c "envsubst '$${BOT_HOST},$${DATA_HOST},$${DATA_WHITELIST_IP}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"
@@ -52,6 +57,8 @@ services:
       - data
       - bot
       - portainer
+    logging:
+      <<: *logging
 
 volumes:
   portainer_data:

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,24 @@
       <version>2.2.0</version>
     </dependency>
 
+    <!--java.xml.bind-->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.3.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.3.0.1</version>
+    </dependency>
+    <!--java.xml.bind-->
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <jda.version>3.8.1_439</jda.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
-    <kotlin.version>1.3.0</kotlin.version>
+    <kotlin.version>1.3.11</kotlin.version>
     <main.class>tech.gdragon.App</main.class>
     <maven.compiler.source>1.9</maven.compiler.source>
     <maven.compiler.target>1.9</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </scm>
 
   <properties>
-    <jda.version>3.8.1_439</jda.version>
+    <jda.version>3.8.1_453</jda.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     <kotlin.version>1.3.11</kotlin.version>
     <main.class>tech.gdragon.App</main.class>

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -13,6 +13,7 @@ import net.dv8tion.jda.core.audio.UserAudio
 import net.dv8tion.jda.core.entities.MessageChannel
 import net.dv8tion.jda.core.entities.TextChannel
 import net.dv8tion.jda.core.entities.VoiceChannel
+import org.apache.commons.io.FileUtils
 import org.jetbrains.exposed.sql.transactions.transaction
 import synapticloop.b2.B2ApiClient
 import tech.gdragon.BotUtils
@@ -171,9 +172,9 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
       }
     }
 
-    val recordingSizeInMB = recording.length().toDouble() / 1024 / 1024
+    val recordingSizeInMB = FileUtils.byteCountToDisplaySize(recording.length())
 
-    logger.info("{}#{}: Saving audio file {} - {}MB.",  voiceChannel?.guild?.name, voiceChannel?.name, recording.name, recordingSizeInMB)
+    logger.info("{}#{}: Saving audio file {} - {}.",  voiceChannel?.guild?.name, voiceChannel?.name, recording.name, recordingSizeInMB)
     logger.debug("Recording size in bytes: {}", recordingSize)
 
     uploadRecording(recording, recordingSizeInMB, voiceChannel, textChannel)
@@ -214,13 +215,13 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
       }
     }
 
-    val recordingSizeInMB = recording.length().toDouble() / 1024 / 1024
-    logger.info("{}#{}: Saving audio clip {} - {}MB.",  voiceChannel?.guild?.name, voiceChannel?.name, recording.name, recordingSizeInMB)
+    val recordingSizeInMB = FileUtils.byteCountToDisplaySize(recording.length())
+    logger.info("{}#{}: Saving audio clip {} - {}.",  voiceChannel?.guild?.name, voiceChannel?.name, recording.name, recordingSizeInMB)
 
     uploadRecording(recording, recordingSizeInMB, voiceChannel, channel)
   }
 
-  private fun uploadRecording(recording: File, recordingSize: Double, voiceChannel: VoiceChannel?, channel: TextChannel?) {
+  private fun uploadRecording(recording: File, recordingSize: String, voiceChannel: VoiceChannel?, channel: TextChannel?) {
     val guildName = channel?.guild?.name
     val voiceChannelName = voiceChannel?.name
 
@@ -259,7 +260,7 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
         logger.warn("B2 Bucket ID not set.")
       }
     } else {
-      BotUtils.sendMessage(channel, "Could not upload, file too large: " + recordingSize + "MB.")
+      BotUtils.sendMessage(channel, "Could not upload, file too large: $recordingSize.")
     }
   }
 


### PR DESCRIPTION
Need a way to know more about the bot's data, and previously was using datasette, but had a lot of issues with the way it presented and queried for data, so instead switching to Metabase.

This will be part of the `docker-compose.yml` file only, and it's an opt-in kind of thing. This does not affect anyone using the fat jar.