### PR TITLE
Remove Inactive Guilds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </scm>
 
   <properties>
-    <jda.version>3.8.1_453</jda.version>
+    <jda.version>3.8.1_454</jda.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     <kotlin.version>1.3.11</kotlin.version>
     <main.class>tech.gdragon.App</main.class>

--- a/sql/V20190103211751__add-guild-region.sql
+++ b/sql/V20190103211751__add-guild-region.sql
@@ -1,0 +1,2 @@
+alter table Guilds
+  add region TEXT;

--- a/sql/V20190103232946__add-guild-created-on.sql
+++ b/sql/V20190103232946__add-guild-created-on.sql
@@ -1,0 +1,2 @@
+alter table Guilds
+  add created_on text;

--- a/sql/V20190103232946__add-guild-created-on.sql
+++ b/sql/V20190103232946__add-guild-created-on.sql
@@ -1,2 +1,2 @@
 alter table Guilds
-  add created_on text;
+  add created_on text default '2019-01-01T00:00:00.000Z';

--- a/sql/V20190103232946__add-guild-created-on.sql
+++ b/sql/V20190103232946__add-guild-created-on.sql
@@ -1,2 +1,2 @@
 alter table Guilds
-  add created_on text default '2019-01-01T00:00:00.000Z';
+  add created_on text default '2019-01-01 00:00:00';

--- a/sql/V20190105223459__add-guild-last-activity-on.sql
+++ b/sql/V20190105223459__add-guild-last-activity-on.sql
@@ -1,2 +1,2 @@
 alter table Guilds
-  add last_active_on text default '2019-01-01T00:00:00.000Z';
+  add last_active_on text default '2019-01-01 00:00:00';

--- a/sql/V20190105223459__add-guild-last-activity-on.sql
+++ b/sql/V20190105223459__add-guild-last-activity-on.sql
@@ -1,0 +1,2 @@
+alter table Guilds
+  add last_active_on text default '2019-01-01T00:00:00.000Z';

--- a/sql/V20190106000238__update-recording-time-to-utc.sql
+++ b/sql/V20190106000238__update-recording-time-to-utc.sql
@@ -1,8 +1,6 @@
 update Recordings
-set created_on = strftime('%Y-%m-%dT%H:%M:%fZ', datetime(created_on, '+8 hours'))
-where created_on not like '%Z';
+set created_on = datetime(created_on, '+8 hours');
 
 update Recordings
-set modified_on = strftime('%Y-%m-%dT%H:%M:%fZ', datetime(modified_on, '+8 hours'))
-where modified_on not null
-  and modified_on not like '%Z';
+set modified_on = datetime(modified_on, '+8 hours')
+where modified_on not null;

--- a/sql/V20190106000238__update-recording-time-to-utc.sql
+++ b/sql/V20190106000238__update-recording-time-to-utc.sql
@@ -1,0 +1,8 @@
+update Recordings
+set created_on = strftime('%Y-%m-%dT%H:%M:%fZ', datetime(created_on, '+8 hours'))
+where created_on not like '%Z';
+
+update Recordings
+set modified_on = strftime('%Y-%m-%dT%H:%M:%fZ', datetime(modified_on, '+8 hours'))
+where modified_on not null
+  and modified_on not like '%Z';

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -32,3 +32,15 @@ where url not null
 group by guilds.name
 having recorded_minutes > 1
 order by recorded_minutes desc;
+
+select datetime(created_on, 'localtime') as created_on, name
+from Guilds
+where id = 333055724198559745
+  and ifnull(created_on, '') not like '%Z';
+
+
+-- Adjust time by adding 8 hours and formatting to proper format
+update Guilds
+set created_on = strftime('%Y-%m-%dT%H:%M:%fZ',datetime(created_on, '+8 hours'))
+where id = 333055724198559745
+  and ifnull(created_on, '') not like '%Z';

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -1,0 +1,34 @@
+-- Recordings that have been made in the last day
+select datetime(created_on)                                                as timestamp,
+       round((julianday(modified_on) - julianday(created_on)) * 1440.0, 2) as duration,
+       url,
+       guilds.name                                                         as guild,
+       channels.name                                                       as channel
+from Recordings
+       join Guilds guilds on Recordings.guild = guilds.id
+       join Channels channels on Recordings.channel = channels.id
+where url notnull
+  and (julianday('now', 'localtime') - julianday(created_on)) < 1.12
+order by created_on desc;
+
+
+select guilds.name as Guild,
+       count(*)    as Count
+from Recordings
+       left join Guilds guilds on Recordings.guild = guilds.id
+where Recordings.modified_on IS NULL
+  and (julianday('now') - julianday(created_on)) < 1.5
+order by Count desc;
+
+
+select guilds.name                                                                      as guild,
+       printf('%05.2f', sum((julianday(modified_on) - julianday(created_on)) * 1440.0)) as recorded_minutes,
+       count(*)                                                                         as recordings
+from Recordings
+       join Guilds guilds on Recordings.guild = guilds.id
+       join Channels channels on Recordings.channel = channels.id
+where url not null
+  and (julianday('now') - julianday(created_on)) < 1.5
+group by guilds.name
+having recorded_minutes > 1
+order by recorded_minutes desc;

--- a/sql/queries.sql
+++ b/sql/queries.sql
@@ -41,6 +41,13 @@ where id = 333055724198559745
 
 -- Adjust time by adding 8 hours and formatting to proper format
 update Guilds
-set created_on = strftime('%Y-%m-%dT%H:%M:%fZ',datetime(created_on, '+8 hours'))
+set created_on = strftime('%Y-%m-%dT%H:%M:%fZ', datetime(created_on, '+8 hours'))
 where id = 333055724198559745
   and ifnull(created_on, '') not like '%Z';
+
+
+select *
+from Guilds
+where date(last_active_on)
+  not between date('now', '-30 days') and date('now')
+limit 50;

--- a/src/main/kotlin/tech/gdragon/App.kt
+++ b/src/main/kotlin/tech/gdragon/App.kt
@@ -3,7 +3,6 @@ package tech.gdragon
 import fi.iki.elonen.NanoHTTPD
 import mu.KotlinLogging
 import tech.gdragon.db.Shim
-import tech.gdragon.db.removeAncientGuilds
 import tech.gdragon.discord.Bot
 import java.io.IOException
 import java.nio.file.Files
@@ -61,7 +60,7 @@ class App private constructor(port: Int, val clientId: String, val inviteUrl: St
       logger.info { "Start background process to remove unused Guilds." }
       Timer("remove-old-guilds", true)
         .scheduleAtFixedRate(0L, Duration.ofDays(1L).toMillis()) {
-          removeAncientGuilds()
+          BotUtils.leaveAncientGuilds(bot.api)
         }
 
       try {

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -81,6 +81,8 @@ object BotUtils {
               val message = ":no_entry_sign: _Cannot autojoin **<#${channel.id}>**, need permission:_ ```${ex.permission}```"
               BotUtils.sendMessage(saveLocation, message)
             }
+
+            Guild.updateActivity(guild.idLong, guild.region.name)
           }
         }
     }

--- a/src/main/kotlin/tech/gdragon/TestApp.kt
+++ b/src/main/kotlin/tech/gdragon/TestApp.kt
@@ -72,7 +72,8 @@ fun testBiggestChannel() {
         super.onGuildVoiceLeave(event)
       }
     })
-    .buildBlocking()
+    .build()
+    .awaitReady()
 }
 
 fun testAlerts() {
@@ -86,7 +87,8 @@ fun testAlerts() {
         super.onGuildVoiceJoin(event)
       }
     })
-    .buildBlocking()
+    .build()
+    .awaitReady()
 }
 
 fun uploadRecording() {

--- a/src/main/kotlin/tech/gdragon/TestApp.kt
+++ b/src/main/kotlin/tech/gdragon/TestApp.kt
@@ -5,16 +5,17 @@ import net.dv8tion.jda.core.JDABuilder
 import net.dv8tion.jda.core.events.guild.voice.GuildVoiceJoinEvent
 import net.dv8tion.jda.core.events.guild.voice.GuildVoiceLeaveEvent
 import net.dv8tion.jda.core.hooks.ListenerAdapter
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.joda.time.DateTime
 import synapticloop.b2.B2ApiClient
 import tech.gdragon.db.Shim
 import tech.gdragon.db.dao.Alias
 import tech.gdragon.db.dao.Channel
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.db.table.Tables
+import tech.gdragon.db.table.Tables.Guilds
 import java.sql.Connection
 
 fun dropAllTables() {
@@ -110,8 +111,19 @@ fun testAutoJoin() {
 
     settings
       ?.channels
-      ?.firstOrNull{ it.id.value == 41992802040138956L }
+      ?.firstOrNull { it.id.value == 41992802040138956L }
       ?.let { println(it.id.value) }
+  }
+}
+
+fun removeUnusedGuilds() {
+  Shim.initializeDatabase("./data/settings.db")
+
+  transaction {
+    Guilds.deleteWhere {
+      val now = DateTime.now()
+      not(Guilds.lastActiveOn.between(now.minusDays(30), now))
+    }
   }
 }
 
@@ -120,5 +132,6 @@ fun main(args: Array<String>) {
 //  basicTest()
 //  dropAllTables()
 //  uploadRecording()
-  testAutoJoin()
+//  testAutoJoin()
+  removeUnusedGuilds()
 }

--- a/src/main/kotlin/tech/gdragon/TestApp.kt
+++ b/src/main/kotlin/tech/gdragon/TestApp.kt
@@ -40,7 +40,7 @@ fun basicTest() {
     SchemaUtils.create(*Tables.allTables)
   }
 
-  val guild = Guild.findOrCreate(333055724198559745L, "Guacamole Dragon")
+  val guild = Guild.findOrCreate(333055724198559745L, "Guacamole Dragon", "US West")
 
   transaction {
     Channel.new(346340766039146506L) {

--- a/src/main/kotlin/tech/gdragon/commands/Commands.kt
+++ b/src/main/kotlin/tech/gdragon/commands/Commands.kt
@@ -1,0 +1,32 @@
+package tech.gdragon.commands
+
+import net.dv8tion.jda.core.entities.TextChannel
+import net.dv8tion.jda.core.managers.AudioManager
+import org.jetbrains.exposed.sql.transactions.transaction
+import tech.gdragon.BotUtils
+import tech.gdragon.db.dao.Guild
+import tech.gdragon.listener.CombinedAudioRecorderHandler
+
+object Commands {
+  fun leave(guildId: Long, audioManager: AudioManager, channel: TextChannel?): String {
+    return transaction {
+      val guild = Guild.findById(guildId)
+
+      if (audioManager.isConnected) {
+        val voiceChannel = audioManager.connectedChannel
+
+        guild?.settings?.let {
+          if (it.autoSave) {
+            val audioReceiveHandler = audioManager.receiveHandler as CombinedAudioRecorderHandler
+            audioReceiveHandler.saveRecording(voiceChannel, channel)
+          }
+        }
+
+        BotUtils.leaveVoiceChannel(voiceChannel)
+        ":wave: _Leaving **<#${voiceChannel.id}>**_"
+      } else {
+        ":no_entry_sign: _I am not in a channel_"
+      }
+    }
+  }
+}

--- a/src/main/kotlin/tech/gdragon/commands/settings/AutoJoin.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/AutoJoin.kt
@@ -6,13 +6,18 @@ import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
 import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Channel
+import tech.gdragon.db.dao.Guild
 import net.dv8tion.jda.core.entities.Channel as DiscordChannel
 
 class AutoJoin : Command {
   private fun updateChannelAutoJoin(channel: DiscordChannel, autoJoin: Int?) {
     transaction {
+      val guild = channel.guild.run {
+        Guild.findOrCreate(idLong, name, region.name)
+      }
+
       Channel
-        .findOrCreate(channel.idLong, channel.name, channel.guild.idLong, channel.guild.name)
+        .findOrCreate(channel.idLong, channel.name, guild)
         .also { it.autoJoin = autoJoin }
     }
   }

--- a/src/main/kotlin/tech/gdragon/commands/settings/AutoLeave.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/AutoLeave.kt
@@ -6,13 +6,18 @@ import tech.gdragon.BotUtils
 import tech.gdragon.commands.Command
 import tech.gdragon.commands.InvalidCommand
 import tech.gdragon.db.dao.Channel
+import tech.gdragon.db.dao.Guild
 import net.dv8tion.jda.core.entities.Channel as DiscordChannel
 
 class AutoLeave : Command {
   private fun updateChannelAutoLeave(channel: DiscordChannel, autoLeave: Int) {
     transaction {
+      val guild = channel.guild.run {
+        Guild.findOrCreate(idLong, name, region.name)
+      }
+
       Channel
-        .findOrCreate(channel.idLong, channel.name, channel.guild.idLong, channel.guild.name)
+        .findOrCreate(channel.idLong, channel.name, guild)
 //        .forEach { it.autoLeave = autoLeave }
     }
   }

--- a/src/main/kotlin/tech/gdragon/db/DateColumnType.kt
+++ b/src/main/kotlin/tech/gdragon/db/DateColumnType.kt
@@ -1,0 +1,67 @@
+package tech.gdragon.db
+
+import org.jetbrains.exposed.sql.ColumnType
+import org.jetbrains.exposed.sql.LiteralOp
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.jetbrains.exposed.sql.vendors.DatabaseDialect
+import org.jetbrains.exposed.sql.vendors.SQLiteDialect
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.ISODateTimeFormat
+import java.util.*
+
+private val DEFAULT_DATE_STRING_FORMATTER = DateTimeFormat.forPattern("YYYY-MM-dd").withLocale(Locale.ROOT)
+private val DEFAULT_DATE_TIME_STRING_FORMATTER = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss.SSSSSS").withLocale(Locale.ROOT)
+private val SQLITE_DATE_TIME_STRING_FORMATTER = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss")
+private val SQLITE_DATE_STRING_FORMATTER = ISODateTimeFormat.yearMonthDay()
+
+internal val currentDialect: DatabaseDialect get() = TransactionManager.current().db.dialect
+
+class DateColumnType(val time: Boolean) : ColumnType() {
+  override fun sqlType(): String = if (time) currentDialect.dataTypeProvider.dateTimeType() else "DATE"
+
+  override fun nonNullValueToString(value: Any): String {
+    if (value is String) return value
+
+    val dateTime = when (value) {
+      is DateTime -> value
+      is java.sql.Date -> DateTime(value.time)
+      is java.sql.Timestamp -> DateTime(value.time)
+      else -> error("Unexpected value: $value of ${value::class.qualifiedName}")
+    }
+
+    return if (time)
+      "'${DEFAULT_DATE_TIME_STRING_FORMATTER.print(dateTime.toDateTime(DateTimeZone.getDefault()))}'"
+    else
+      "'${DEFAULT_DATE_STRING_FORMATTER.print(dateTime)}'"
+  }
+
+  override fun valueFromDB(value: Any): Any = when (value) {
+    is DateTime -> value
+    is java.sql.Date -> DateTime(value.time)
+    is java.sql.Timestamp -> DateTime(value.time)
+    is Int -> DateTime(value.toLong())
+    is Long -> DateTime(value)
+    is String -> when {
+      currentDialect is SQLiteDialect && time -> SQLITE_DATE_TIME_STRING_FORMATTER.parseDateTime(value)
+      currentDialect is SQLiteDialect -> SQLITE_DATE_STRING_FORMATTER.parseDateTime(value)
+      else -> value
+    }
+    // REVIEW
+    else -> DEFAULT_DATE_TIME_STRING_FORMATTER.parseDateTime(value.toString())
+  }
+
+  override fun notNullValueToDB(value: Any): Any {
+    if (value is DateTime) {
+      return if (time) {
+        SQLITE_DATE_TIME_STRING_FORMATTER.print(value)
+      } else {
+        SQLITE_DATE_STRING_FORMATTER.print(value)
+      }
+    }
+    return value
+  }
+}
+
+fun dateTimeLiteral(value: DateTime): LiteralOp<DateTime> = LiteralOp(DateColumnType(true), value)

--- a/src/main/kotlin/tech/gdragon/db/Shim.kt
+++ b/src/main/kotlin/tech/gdragon/db/Shim.kt
@@ -3,6 +3,7 @@ package tech.gdragon.db
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.joda.time.DateTimeZone
 import java.sql.Connection
 
 /**
@@ -10,6 +11,9 @@ import java.sql.Connection
  */
 object Shim {
   fun initializeDatabase(database: String) {
+    // Ensure that Joda Time deals with time as UTC
+    DateTimeZone.setDefault(DateTimeZone.UTC)
+
     Database.connect("jdbc:sqlite:$database", driver = "org.sqlite.JDBC", setupConnection = {
       val statement = it.createStatement()
       statement.executeUpdate("PRAGMA foreign_keys = ON")

--- a/src/main/kotlin/tech/gdragon/db/Util.kt
+++ b/src/main/kotlin/tech/gdragon/db/Util.kt
@@ -1,10 +1,11 @@
 package tech.gdragon.db
 
+import org.jetbrains.exposed.sql.Between
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.not
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.joda.time.DateTime
-import tech.gdragon.db.table.Tables
+import tech.gdragon.db.table.Tables.Guilds
 
 fun nowUTC(): DateTime = DateTime.now()
 
@@ -13,9 +14,9 @@ fun nowUTC(): DateTime = DateTime.now()
  */
 fun removeAncientGuilds() {
   transaction {
-    Tables.Guilds.deleteWhere {
+    Guilds.deleteWhere {
       val now = DateTime.now()
-      not(Tables.Guilds.lastActiveOn.between(now.minusDays(30), now))
+      not(Between(Guilds.lastActiveOn, dateTimeLiteral(now.minusDays(30)), dateTimeLiteral(now)))
     }
   }
 }

--- a/src/main/kotlin/tech/gdragon/db/Util.kt
+++ b/src/main/kotlin/tech/gdragon/db/Util.kt
@@ -1,22 +1,6 @@
 package tech.gdragon.db
 
-import org.jetbrains.exposed.sql.Between
-import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.not
-import org.jetbrains.exposed.sql.transactions.transaction
 import org.joda.time.DateTime
-import tech.gdragon.db.table.Tables.Guilds
+import net.dv8tion.jda.core.entities.Guild as DiscordGuild
 
 fun nowUTC(): DateTime = DateTime.now()
-
-/**
- * Removes any Guild that hasn't been active in the past 30 days.
- */
-fun removeAncientGuilds() {
-  transaction {
-    Guilds.deleteWhere {
-      val now = DateTime.now()
-      not(Between(Guilds.lastActiveOn, dateTimeLiteral(now.minusDays(30)), dateTimeLiteral(now)))
-    }
-  }
-}

--- a/src/main/kotlin/tech/gdragon/db/Util.kt
+++ b/src/main/kotlin/tech/gdragon/db/Util.kt
@@ -6,6 +6,8 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.joda.time.DateTime
 import tech.gdragon.db.table.Tables
 
+fun nowUTC(): DateTime = DateTime.now()
+
 /**
  * Removes any Guild that hasn't been active in the past 30 days.
  */

--- a/src/main/kotlin/tech/gdragon/db/Util.kt
+++ b/src/main/kotlin/tech/gdragon/db/Util.kt
@@ -1,0 +1,19 @@
+package tech.gdragon.db
+
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.not
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.joda.time.DateTime
+import tech.gdragon.db.table.Tables
+
+/**
+ * Removes any Guild that hasn't been active in the past 30 days.
+ */
+fun removeAncientGuilds() {
+  transaction {
+    Tables.Guilds.deleteWhere {
+      val now = DateTime.now()
+      not(Tables.Guilds.lastActiveOn.between(now.minusDays(30), now))
+    }
+  }
+}

--- a/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
+++ b/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.exposedLogger
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
+import tech.gdragon.db.table.Tables
 import tech.gdragon.db.table.Tables.Aliases
 import tech.gdragon.db.table.Tables.Channels
 import tech.gdragon.db.table.Tables.Guilds
@@ -68,14 +69,17 @@ class Guild(id: EntityID<Long>) : LongEntity(id) {
     // TODO: Remove region from the method signature
     fun updateActivity(guildId: Long, region: String) {
       transaction {
-        val guild = Guild.findById(guildId)
-        guild?.region = region
+        Guild.findById(guildId)?.let {
+          it.lastActiveOn = Tables.nowUTC()
+          it.region = region
+        }
       }
     }
   }
 
   val createdOn by Guilds.createdOn
   var name by Guilds.name
+  var lastActiveOn by Guilds.lastActiveOn
   var region by Guilds.region
   val settings by Settings backReferencedOn SettingsTable.guild
 }

--- a/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
+++ b/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
@@ -5,7 +5,7 @@ import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.exposedLogger
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
-import tech.gdragon.db.table.Tables
+import tech.gdragon.db.nowUTC
 import tech.gdragon.db.table.Tables.Aliases
 import tech.gdragon.db.table.Tables.Channels
 import tech.gdragon.db.table.Tables.Guilds
@@ -70,7 +70,7 @@ class Guild(id: EntityID<Long>) : LongEntity(id) {
     fun updateActivity(guildId: Long, region: String) {
       transaction {
         Guild.findById(guildId)?.let {
-          it.lastActiveOn = Tables.jodaNowUTC()
+          it.lastActiveOn = nowUTC()
           it.region = region
         }
       }

--- a/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
+++ b/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
@@ -64,8 +64,17 @@ class Guild(id: EntityID<Long>) : LongEntity(id) {
         Alias.createDefaultAliases(Settings.new { this.guild = guild })
       }
     }
+
+    // TODO: Remove region from the method signature
+    fun updateActivity(guildId: Long, region: String) {
+      transaction {
+        val guild = Guild.findById(guildId)
+        guild?.region = region
+      }
+    }
   }
 
+  val createdOn by Guilds.createdOn
   var name by Guilds.name
   var region by Guilds.region
   val settings by Settings backReferencedOn SettingsTable.guild

--- a/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
+++ b/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
@@ -70,7 +70,7 @@ class Guild(id: EntityID<Long>) : LongEntity(id) {
     fun updateActivity(guildId: Long, region: String) {
       transaction {
         Guild.findById(guildId)?.let {
-          it.lastActiveOn = Tables.nowUTC()
+          it.lastActiveOn = Tables.jodaNowUTC()
           it.region = region
         }
       }

--- a/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
+++ b/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
@@ -32,8 +32,7 @@ class Alias(id: EntityID<Int>) : IntEntity(id) {
 
 class Channel(id: EntityID<Long>) : LongEntity(id) {
   companion object : LongEntityClass<Channel>(Channels) {
-    fun findOrCreate(id: Long, name: String, guildId: Long, guildName: String): Channel {
-      val guild = Guild.findOrCreate(guildId, guildName)
+    fun findOrCreate(id: Long, name: String, guild: Guild): Channel {
 
       return find { (Channels.settings eq guild.settings.id) and (Channels.id eq id) }.firstOrNull() ?: Channel.new(id) {
         this.name = name
@@ -53,9 +52,10 @@ class Guild(id: EntityID<Long>) : LongEntity(id) {
   companion object : LongEntityClass<Guild>(Guilds) {
 
     @JvmStatic
-    fun findOrCreate(id: Long, name: String): Guild {
+    fun findOrCreate(id: Long, name: String, region: String): Guild {
       return Guild.findById(id) ?: Guild.new(id) {
         this.name = name
+        this.region = region
       }.also { guild ->
         // Please ensure Guild is created before proceeding
         exposedLogger.info("Creating Guild database entry for: ${guild.name}")
@@ -67,6 +67,7 @@ class Guild(id: EntityID<Long>) : LongEntity(id) {
   }
 
   var name by Guilds.name
+  var region by Guilds.region
   val settings by Settings backReferencedOn SettingsTable.guild
 }
 

--- a/src/main/kotlin/tech/gdragon/db/table/Tables.kt
+++ b/src/main/kotlin/tech/gdragon/db/table/Tables.kt
@@ -3,20 +3,22 @@ package tech.gdragon.db.table
 import org.jetbrains.exposed.dao.IntIdTable
 import org.jetbrains.exposed.dao.LongIdTable
 import org.jetbrains.exposed.sql.ReferenceOption
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import java.math.BigDecimal
-import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 object Tables {
   fun nowUTC(): String = ZonedDateTime.now(ZoneId.of("Z")).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
+  fun jodaNowUTC(): DateTime = DateTime.now(DateTimeZone.UTC)
 
   object Guilds : LongIdTable() {
     val name = text("name")
     val region = text("region")
     val createdOn = text("created_on").clientDefault(::nowUTC)
-    val lastActiveOn = text("last_active_on")
+    val lastActiveOn = datetime("last_active_on")
   }
 
   object Settings : LongIdTable() {

--- a/src/main/kotlin/tech/gdragon/db/table/Tables.kt
+++ b/src/main/kotlin/tech/gdragon/db/table/Tables.kt
@@ -3,21 +3,14 @@ package tech.gdragon.db.table
 import org.jetbrains.exposed.dao.IntIdTable
 import org.jetbrains.exposed.dao.LongIdTable
 import org.jetbrains.exposed.sql.ReferenceOption
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
+import tech.gdragon.db.nowUTC
 import java.math.BigDecimal
-import java.time.ZoneId
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 
 object Tables {
-  fun nowUTC(): String = ZonedDateTime.now(ZoneId.of("Z")).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
-  fun jodaNowUTC(): DateTime = DateTime.now(DateTimeZone.UTC)
-
   object Guilds : LongIdTable() {
     val name = text("name")
     val region = text("region")
-    val createdOn = text("created_on").clientDefault(::nowUTC)
+    val createdOn = datetime("created_on").clientDefault(::nowUTC)
     val lastActiveOn = datetime("last_active_on")
   }
 
@@ -54,8 +47,8 @@ object Tables {
   object Recordings : LongIdTable() {
     val channel = reference("channel", Channels)
     val size = long("size").default(0)
-    val createdOn = text("created_on").clientDefault(::nowUTC)
-    val modifiedOn = text("modified_on").nullable()
+    val createdOn = datetime("created_on").clientDefault(::nowUTC)
+    val modifiedOn = datetime("modified_on").nullable()
     val url = text("url").nullable()
     val guild = reference("guild", Guilds, ReferenceOption.CASCADE)
   }

--- a/src/main/kotlin/tech/gdragon/db/table/Tables.kt
+++ b/src/main/kotlin/tech/gdragon/db/table/Tables.kt
@@ -3,6 +3,8 @@ package tech.gdragon.db.table
 import org.jetbrains.exposed.dao.IntIdTable
 import org.jetbrains.exposed.dao.LongIdTable
 import org.jetbrains.exposed.sql.ReferenceOption
+import org.joda.time.DateTime
+import tech.gdragon.db.DateColumnType
 import tech.gdragon.db.nowUTC
 import java.math.BigDecimal
 
@@ -10,8 +12,8 @@ object Tables {
   object Guilds : LongIdTable() {
     val name = text("name")
     val region = text("region")
-    val createdOn = datetime("created_on").clientDefault(::nowUTC)
-    val lastActiveOn = datetime("last_active_on")
+    val createdOn = registerColumn<DateTime>("created_on", DateColumnType(true)).clientDefault(::nowUTC)
+    val lastActiveOn = registerColumn<DateTime>("last_active_on", DateColumnType(true))
   }
 
   object Settings : LongIdTable() {
@@ -47,8 +49,8 @@ object Tables {
   object Recordings : LongIdTable() {
     val channel = reference("channel", Channels)
     val size = long("size").default(0)
-    val createdOn = datetime("created_on").clientDefault(::nowUTC)
-    val modifiedOn = datetime("modified_on").nullable()
+    val createdOn = registerColumn<DateTime>("created_on", DateColumnType(true)).clientDefault(::nowUTC)
+    val modifiedOn = registerColumn<DateTime>("modified_on", DateColumnType(true)).nullable()
     val url = text("url").nullable()
     val guild = reference("guild", Guilds, ReferenceOption.CASCADE)
   }

--- a/src/main/kotlin/tech/gdragon/db/table/Tables.kt
+++ b/src/main/kotlin/tech/gdragon/db/table/Tables.kt
@@ -16,6 +16,7 @@ object Tables {
     val name = text("name")
     val region = text("region")
     val createdOn = text("created_on").clientDefault(::nowUTC)
+    val lastActiveOn = text("last_active_on")
   }
 
   object Settings : LongIdTable() {

--- a/src/main/kotlin/tech/gdragon/db/table/Tables.kt
+++ b/src/main/kotlin/tech/gdragon/db/table/Tables.kt
@@ -10,6 +10,7 @@ import java.time.format.DateTimeFormatter
 object Tables {
   object Guilds : LongIdTable() {
     val name = text("name")
+    val region = text("region")
   }
 
   object Settings : LongIdTable() {

--- a/src/main/kotlin/tech/gdragon/db/table/Tables.kt
+++ b/src/main/kotlin/tech/gdragon/db/table/Tables.kt
@@ -52,7 +52,7 @@ object Tables {
   object Recordings : LongIdTable() {
     val channel = reference("channel", Channels)
     val size = long("size").default(0)
-    val createdOn = text("created_on").clientDefault { LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) }
+    val createdOn = text("created_on").clientDefault(::nowUTC)
     val modifiedOn = text("modified_on").nullable()
     val url = text("url").nullable()
     val guild = reference("guild", Guilds, ReferenceOption.CASCADE)

--- a/src/main/kotlin/tech/gdragon/db/table/Tables.kt
+++ b/src/main/kotlin/tech/gdragon/db/table/Tables.kt
@@ -5,12 +5,17 @@ import org.jetbrains.exposed.dao.LongIdTable
 import org.jetbrains.exposed.sql.ReferenceOption
 import java.math.BigDecimal
 import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 object Tables {
+  fun nowUTC(): String = ZonedDateTime.now(ZoneId.of("Z")).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
+
   object Guilds : LongIdTable() {
     val name = text("name")
     val region = text("region")
+    val createdOn = text("created_on").clientDefault(::nowUTC)
   }
 
   object Settings : LongIdTable() {

--- a/src/main/kotlin/tech/gdragon/discord/Bot.kt
+++ b/src/main/kotlin/tech/gdragon/discord/Bot.kt
@@ -25,7 +25,8 @@ class Bot(token: String) {
       Permission.MESSAGE_WRITE,
       Permission.VOICE_CONNECT,
       Permission.VOICE_USE_VAD,
-      Permission.VOICE_SPEAK
+      Permission.VOICE_SPEAK,
+      Permission.NICKNAME_CHANGE
     )
   }
 

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -109,11 +109,12 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
     recordingRecord = transaction {
       Guild.findById(voiceChannel.guild.idLong)?.let {
         Recording.new {
-          channel = Channel.findOrCreate(voiceChannel.idLong, voiceChannel.name, it.id.value, it.name)
+          channel = Channel.findOrCreate(voiceChannel.idLong, voiceChannel.name, it)
           guild = it
         }
       }
     }
+
     subject = PublishSubject.create()
     uuid = UUID.randomUUID()
     filename = "$dataDirectory/recordings/$uuid.mp3"

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -20,14 +20,13 @@ import tech.gdragon.BotUtils
 import tech.gdragon.db.dao.Channel
 import tech.gdragon.db.dao.Guild
 import tech.gdragon.db.dao.Recording
+import tech.gdragon.db.nowUTC
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
@@ -252,7 +251,7 @@ class CombinedAudioRecorderHandler(val volume: Double, val voiceChannel: VoiceCh
         transaction {
           recordingRecord?.apply {
             size = recording.length()
-            modifiedOn = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            modifiedOn = nowUTC()
             url = recordingUrl
           }
         }

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -200,4 +200,3 @@ class EventListener : ListenerAdapter() {
     }*/
   }
 }
-

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -113,6 +113,8 @@ class EventListener : ListenerAdapter() {
           BotUtils.sendMessage(channel, ":no_entry_sign: _Usage: `${e.usage(prefix)}`_")
           logger.warn { "${event.guild.name}#${channel.name}: [$rawContent] ${e.reason}" }
         }
+
+        Guild.updateActivity(event.guild.idLong, event.guild.region.name)
       }
     }
   }
@@ -157,6 +159,7 @@ class EventListener : ListenerAdapter() {
 
     // Add guild if not present
 
+    logger.info { "Add any missing Guilds to the Database..." }
     event.jda.guilds.forEach {
       transaction {
         tech.gdragon.db.dao.Guild.findOrCreate(it.idLong, it.name, it.region.name)
@@ -172,19 +175,20 @@ class EventListener : ListenerAdapter() {
         logger.info("Creating: " + dir.toString())
       }
 
+      logger.info { "Performing audio file cleanup if necessary..." }
       Files
         .list(dir)
         .filter { path -> Files.isRegularFile(path) && path.toString().toLowerCase().endsWith(".mp3") }
         .forEach { path ->
           try {
             Files.delete(path)
-            logger.info("Deleting file $path...")
-          } catch (e1: IOException) {
-            logger.error("Could not delete: " + path, e1)
+            logger.info { "Deleting file $path..." }
+          } catch (e: IOException) {
+            logger.error(e) { "Could not delete: $path" }
           }
         }
-    } catch (e1: IOException) {
-      logger.error("Error preparing to read recordings", e1)
+    } catch (e: IOException) {
+      logger.error(e) { "Error preparing to read recordings" }
     }
 
     //check for servers to join

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -30,7 +30,7 @@ class EventListener : ListenerAdapter() {
   override fun onGuildJoin(event: GuildJoinEvent) {
     transaction {
       val guild = event.guild
-      Guild.findOrCreate(guild.idLong, guild.name)
+      Guild.findOrCreate(guild.idLong, guild.name, guild.region.name)
     }
 
     logger.info { "Joined new server '${event.guild.name}', connected to ${event.jda.guilds.size} guilds." }
@@ -83,7 +83,7 @@ class EventListener : ListenerAdapter() {
     val prefix = transaction {
       // HACK: Create settings for a guild that needs to be accessed. This is a problem when restarting bot.
       // TODO: On bot initialization, I should be able to check which Guilds the bot is connected to and purge/add respectively
-      val guild = Guild.findById(guildId) ?: Guild.findOrCreate(guildId, event.guild.name)
+      val guild = Guild.findById(guildId) ?: Guild.findOrCreate(guildId, event.guild.name, event.guild.region.name)
 
       guild.settings.prefix
     }
@@ -144,7 +144,7 @@ class EventListener : ListenerAdapter() {
 
     event.jda.guilds.forEach {
       transaction {
-        tech.gdragon.db.dao.Guild.findOrCreate(it.idLong, it.name)
+        tech.gdragon.db.dao.Guild.findOrCreate(it.idLong, it.name, it.region.name)
       }
     }
 

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -52,10 +52,10 @@ class EventListener : ListenerAdapter() {
   }
 
   override fun onGuildLeave(event: GuildLeaveEvent) {
-    transaction {
+    /*transaction {
       val guild = Guild.findById(event.guild.idLong)
       guild?.delete()
-    }
+    }*/
 
     logger.info { "Left server '${event.guild.name}', connected to ${event.jda.guilds.size} guilds." }
   }

--- a/src/main/resources/hotswap-agent.properties
+++ b/src/main/resources/hotswap-agent.properties
@@ -1,0 +1,3 @@
+autoHotswap=true
+disablePlugin=AnonymousClassPatchPlugin
+

--- a/src/main/resources/log4j2-dev.xml
+++ b/src/main/resources/log4j2-dev.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
   <Properties>
-    <Property name="globalPattern">%d{YYYY-MM-dd'T'HH:mm:ssZ} [%level] [%t] %logger{36} - %msg%n</Property>
+    <Property name="globalPattern">
+      %d{YYYY-MM-dd'T'HH:mm:ssZ} [%level] %logger{1.} - %mdc{guild}#%mdc{text-channel}: %msg%n
+    </Property>
     <Property name="ROLLBAR_TOKEN"/>
     <Property name="ROLLBAR_ENV"/>
   </Properties>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -9,24 +9,10 @@
     <Console name="Console">
       <PatternLayout pattern="${globalPattern}"/>
     </Console>
-    <Rollbar name="Rollbar">
-      <accessToken>${env:ROLLBAR_TOKEN}</accessToken>
-      <environment>${env:ROLLBAR_ENV}</environment>
-      <language>kotlin</language>
-      <PatternLayout pattern="${globalPattern}"/>
-      <RegexFilter regex=".*Found an unexpected key.*" onMatch="DENY" onMismatch="ACCEPT"/>
-      <RegexFilter regex=".*There was some unexpected exception in the combinedAudioExecutor.*" onMatch="DENY" onMismatch="ACCEPT"/>
-    </Rollbar>
-    <Discord name="Discord">
-      <webhookUrl>${env:DISCORD_WEBHOOK}</webhookUrl>
-      <PatternLayout pattern="${globalPattern}"/>
-      <RegexFilter regex=".*There was some unexpected exception in the combinedAudioExecutor.*" onMatch="DENY" onMismatch="ACCEPT"/>
-    </Discord>
+
   </Appenders>
   <Loggers>
     <Root level="info">
-      <AppenderRef level="error" ref="Rollbar"/>
-      <AppenderRef level="error" ref="Discord"/>
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
   <Properties>
-    <Property name="globalPattern">%d{YYYY-MM-dd'T'HH:mm:ssZ} [%level] [%t] %logger{36} - %msg%n</Property>
+    <Property name="globalPattern">
+      %d{YYYY-MM-dd'T'HH:mm:ssZ} [%level] %logger{1.} - %mdc{guild}#%mdc{text-channel}: %msg%n
+    </Property>
     <Property name="ROLLBAR_TOKEN"/>
     <Property name="ROLLBAR_ENV"/>
   </Properties>
@@ -9,10 +11,28 @@
     <Console name="Console">
       <PatternLayout pattern="${globalPattern}"/>
     </Console>
-
+    <Rollbar name="Rollbar">
+      <accessToken>${env:ROLLBAR_TOKEN}</accessToken>
+      <environment>${env:ROLLBAR_ENV}</environment>
+      <language>kotlin</language>
+      <PatternLayout pattern="${globalPattern}"/>
+      <Filters>
+        <RegexFilter regex=".*Found an unexpected key.*" onMatch="DENY" onMismatch="ACCEPT"/>
+        <RegexFilter regex=".*There was some unexpected exception in the combinedAudioExecutor.*" onMatch="DENY"
+                     onMismatch="ACCEPT"/>
+      </Filters>
+    </Rollbar>
+    <Discord name="Discord">
+      <webhookUrl>${env:DISCORD_WEBHOOK}</webhookUrl>
+      <PatternLayout pattern="${globalPattern}"/>
+      <RegexFilter regex=".*There was some unexpected exception in the combinedAudioExecutor.*" onMatch="DENY"
+                   onMismatch="ACCEPT"/>
+    </Discord>
   </Appenders>
   <Loggers>
     <Root level="info">
+      <AppenderRef level="error" ref="Rollbar"/>
+      <AppenderRef level="error" ref="Discord"/>
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>


### PR DESCRIPTION
Arbitrarily removing Guilds that haven't been active in 30 days.

This is primarily because of performance, the bot will be listening and parsing the text messages until it sees the right prefix. So now there's a background thread running the inactive check every day.

Bundled with this change, there's a few other goodies:
- Timestamps have been normalized and am now using [SQLite's datetime](https://www.sqlite.org/lang_datefunc.html) format
- Guilds have an `region`, `on_created`, `last_active_on`
  - The duplication of the Region is because I want to be able to see that at a glance and not have to use the Discord API to fetch every time. This will be used for defaults on #93 
- UTC everything!
  - For some reason, I chose to use local time for timestamps...I then relocated....then timestamps made no sense. I should know better.

**Another big change here, is that when Guilds choose to leave, I no longer remove their info from the database. Since the bot auto-leaves now, it'd be nice for a User to retain their data, I'll need to find a way for a user to _really_ delete their data if they wanted that.**

Closes #86 