### PR TITLE
PCM Mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     <<: *defaults
     docker:
-        - image: circleci/openjdk:9-jdk
+        - image: circleci/openjdk:11-jdk
     environment:
       # Customize the JVM maximum heap limit
       MAVEN_OPTS: -Xmx3200m

--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.7.9</version>
+            <version>0.8.3</version>
             <executions>
               <execution>
                 <id>prepare-agent</id>


### PR DESCRIPTION
Every now and then I need to create a raw recording file so that I can test the encoding, and the easiest way is to generate a PCM file with the bot, however the code wasn't flexible to let me toggle, but now if I set the environment variable `PCM_MODE` to `true`, all output will be saved to raw PCM.

In the process a few dependencies were updated, CircleCI is now using the JDK 11 container to build which required and update to the coverage plugin.