### PR TITLE
Remove unnecessary aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,20 @@
 
 ## Commands
 
-|                            Command                          |                                                                  Description                                                                   |
-|:------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
-| `!alias [command name] [new command alias]`                 | Creates an alias, or alternate name, to a command for customization.                                                                           |
-| `!autojoin [Voice Channel name \| 'all'] [number \| 'off']` | Sets the number of players for the bot to auto-join a voice channel, or disables auto-joining. 'all' will apply number to all voice channels.  |
-| `!autoleave [Voice Channel name \| 'all'] [number]`         | Sets the number of players for the bot to auto-leave a voice channel, or disables auto-leaving. 'all' will apply number to all voice channels. |
-| `!autosave`                                                 | Toggles the option to automatically save and send all files at the end of each session - not just saved or clipped files                       |
-| `!clip [seconds] \| !clip [seconds] [text channel]`         | Saves a clip of the specified length and outputs it in the current or specified text channel (max 120 seconds)                                 |
-| `!record`                                                   | Ask the bot to join and record your current channel                                                                                            |
-| `!stop`                                                     | Ask the bot to leave it's current channel                                                                                                      |
-| `!prefix [character]`                                       | Sets the prefix for each command to avoid conflict with other bots _(Default is '!')_                                                          |
-| `!removeAlias [alias name]`                                 | Removes an alias from a command.                                                                                                               |
-| `!save \| !save [text channel]`                             | Saves the current recording and outputs it to the current or specified text chats (caps at 16MB)                                               |
-| `!saveLocation \| !saveLocation [text channel \| 'off']`    | Sets the text channel to send all messages to, use `off` to restore default behaviour.                                                         |
-| `!volume [1-100]`                                           | Sets the percentage volume to record at, from 1-100%                                                                                           |
+|                            Command                            |                                                                  Description                                                                    |
+|:--------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| `!alias [command name] [new command alias]`                   | Creates an alias, or alternate name, to a command for customization.                                                                            |
+| `!autorecord [Voice Channel name \| 'all'] [number \| 'off']` | Sets the number of players for the bot to autorecord a voice channel, or disables autorecord-ing. 'all' will apply number to all voice channels.|
+| `!autostop [Voice Channel name \| 'all'] [number]`            | Sets the number of players for the bot to autostop a voice channel, or disables autostop-ing. 'all' will apply number to all voice channels.    |
+| `!autosave`                                                   | Toggles the option to automatically save and send all files at the end of each session - not just saved or clipped files                        |
+| `!clip [seconds] \| !clip [seconds] [text channel]`           | Saves a clip of the specified length and outputs it in the current or specified text channel (max 120 seconds)                                  |
+| `!record`                                                     | Ask the bot to record your current channel                                                                                             |
+| `!stop`                                                       | Ask the bot to stop recording it's current channel                                                                                                       |
+| `!prefix [character]`                                         | Sets the prefix for each command to avoid conflict with other bots _(Default is '!')_                                                           |
+| `!removeAlias [alias name]`                                   | Removes an alias from a command.                                                                                                                |
+| `!save \| !save [text channel]`                               | Saves the current recording and outputs it to the current or specified text chats (caps at 16MB)                                                |
+| `!saveLocation \| !saveLocation [text channel \| 'off']`      | Sets the text channel to send all messages to, use `off` to restore default behaviour.                                                          |
+| `!volume [1-100]`                                             | Sets the percentage volume to record at, from 1-100%                                                                                            |
 
 _Replace brackets [] with item specified. Vertical bar | means 'or', either side of bar is valid choice._
 

--- a/sql/V20190330124302__remove-deprecated-aliases.sql
+++ b/sql/V20190330124302__remove-deprecated-aliases.sql
@@ -1,0 +1,55 @@
+-- Remove stop alias
+delete
+from Aliases
+where name = 'LEAVE'
+  and alias = 'stop';
+
+-- Remove info alias
+delete
+from Aliases
+where name = 'HELP'
+  and alias = 'info';
+
+-- Remove record alias
+delete
+from Aliases
+where name = 'JOIN'
+  and alias = 'record';
+
+-- Remove symbol alias
+delete
+from Aliases
+where name = 'PREFIX'
+  and alias = 'symbol';
+
+-- Remove alias alias, invalid alias
+delete
+from Aliases
+where name = 'ALIAS';
+
+-- Rename LEAVE -> STOP
+update Aliases
+set name = 'STOP'
+where name = 'LEAVE'
+  and not alias = 'stop';
+
+-- Rename JOIN -> RECORD
+update Aliases
+set name = 'RECORD'
+where name = 'JOIN'
+  and not alias = 'record';
+
+-- Rename AUTOLEAVE -> AUTOSTOP
+update Aliases
+set name = 'AUTOSTOP'
+where name = 'AUTOLEAVE';
+
+-- Rename AUTOJOIN -> AUTORECORD
+update Aliases
+set name = 'AUTORECORD'
+where name = 'AUTOJOIN';
+
+-- Remove redundant aliases
+delete
+from Aliases
+where name = upper(alias);

--- a/sql/V20190330163316__rename-leave-to-stop.sql
+++ b/sql/V20190330163316__rename-leave-to-stop.sql
@@ -1,0 +1,20 @@
+create table Channels_dg_tmp
+(
+  id         INTEGER
+    primary key,
+  name       TEXT   not null,
+  autoRecord INT,
+  autoStop   INT default 1 not null,
+  settings   BIGINT not null
+    references Settings
+      on delete cascade
+);
+
+insert into Channels_dg_tmp(id, name, autoRecord, autoStop, settings)
+select id, name, autoRecord, autoLeave, settings
+from Channels;
+
+drop table Channels;
+
+alter table Channels_dg_tmp
+  rename to Channels;

--- a/src/main/kotlin/tech/gdragon/commands/settings/Alias.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/Alias.kt
@@ -26,20 +26,19 @@ class Alias : CommandHandler {
       throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
     }
 
-//    TODO: Cannot alias the alias
     val defaultChannel = BotUtils.defaultTextChannel(event.guild) ?: event.channel
     val command = args.first().toUpperCase()
 
     // Checks that command to alias exists
     if ("ALIAS" == command || Command.values().none { it.name == command }) {
-      BotUtils.sendMessage(defaultChannel, "Invalid command: '${command.toLowerCase()}'")
+      BotUtils.sendMessage(defaultChannel, "Invalid command: `${command.toLowerCase()}`")
     } else {
       val aliases = transaction { Guild.findById(event.guild.idLong)?.settings?.aliases?.toList() }
       val alias = args[1]
 
       // Checks that alias doesn't already exist
       if (aliases?.any { it.name == alias } == true) {
-        BotUtils.sendMessage(defaultChannel, "Alias '$alias' already exists.")
+        BotUtils.sendMessage(defaultChannel, "Alias `$alias` already exists.")
       } else {
         transaction {
           Guild.findById(event.guild.idLong)?.settings?.let {
@@ -49,7 +48,7 @@ class Alias : CommandHandler {
               settings = it
             }
 
-            BotUtils.sendMessage(defaultChannel, "New alias '$alias' set for command '${command.toLowerCase()}'.")
+            BotUtils.sendMessage(defaultChannel, "New alias `$alias` set for command `${command.toLowerCase()}`.")
           }
         }
       }

--- a/src/main/kotlin/tech/gdragon/commands/settings/Alias.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/Alias.kt
@@ -26,12 +26,13 @@ class Alias : CommandHandler {
       throw InvalidCommand(::usage, "Incorrect number of arguments: ${args.size}")
     }
 
+//    TODO: Cannot alias the alias
     val defaultChannel = BotUtils.defaultTextChannel(event.guild) ?: event.channel
-    val command = args.first()
+    val command = args.first().toUpperCase()
 
     // Checks that command to alias exists
-    if (Command.values().none { it.name == command.toUpperCase() }) {
-      BotUtils.sendMessage(defaultChannel, "Command '$command' not found.")
+    if ("ALIAS" == command || Command.values().none { it.name == command }) {
+      BotUtils.sendMessage(defaultChannel, "Invalid command: '${command.toLowerCase()}'")
     } else {
       val aliases = transaction { Guild.findById(event.guild.idLong)?.settings?.aliases?.toList() }
       val alias = args[1]
@@ -43,12 +44,12 @@ class Alias : CommandHandler {
         transaction {
           Guild.findById(event.guild.idLong)?.settings?.let {
             Alias.new {
-              name = command.toUpperCase()
+              name = command
               this.alias = alias
               settings = it
             }
 
-            BotUtils.sendMessage(defaultChannel, "New alias '$alias' set for command '$command'.")
+            BotUtils.sendMessage(defaultChannel, "New alias '$alias' set for command '${command.toLowerCase()}'.")
           }
         }
       }

--- a/src/main/kotlin/tech/gdragon/commands/settings/Aliases.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/Aliases.kt
@@ -1,0 +1,4 @@
+package tech.gdragon.commands.settings
+
+class Aliases {
+}

--- a/src/main/kotlin/tech/gdragon/commands/settings/AutoRecord.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/AutoRecord.kt
@@ -81,7 +81,7 @@ class AutoRecord : CommandHandler {
     BotUtils.sendMessage(defaultChannel, message)
   }
 
-  override fun usage(prefix: String): String = "${prefix}autojoin [Voice Channel name | 'all'] [number | 'off']"
+  override fun usage(prefix: String): String = "${prefix}autorecord [Voice Channel name | 'all'] [number | 'off']"
 
   override fun description(): String = "Sets the number of players for the bot to autorecord a voice channel, or " +
     "disables auto recording. `All` will apply number to all voice channels."

--- a/src/main/kotlin/tech/gdragon/commands/settings/AutoStop.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/AutoStop.kt
@@ -9,7 +9,7 @@ import tech.gdragon.db.dao.Guild
 import net.dv8tion.jda.core.entities.Channel as DiscordChannel
 
 class AutoStop : CommandHandler {
-  private fun updateChannelAutoLeave(channel: DiscordChannel, autoLeave: Int) {
+  private fun updateChannelAutoStop(channel: DiscordChannel, autoStop: Int) {
     transaction {
       val guild = channel.guild.run {
         Guild.findOrCreate(idLong, name, region.name)
@@ -17,7 +17,7 @@ class AutoStop : CommandHandler {
 
       Channel
         .findOrCreate(channel.idLong, channel.name, guild)
-//        .forEach { it.autoLeave = autoLeave }
+//        .forEach { it.autoStop = autoStop }
     }
   }
 
@@ -37,7 +37,7 @@ class AutoStop : CommandHandler {
 
         if (channelName == "all") {
           val channels = event.guild.voiceChannels
-          channels.forEach { updateChannelAutoLeave(it, number) }
+          channels.forEach { updateChannelAutoStop(it, number) }
           "Will now automatically leave any voice channel with $number or less people."
         } else {
           val channels = event.guild.getVoiceChannelsByName(channelName, true)
@@ -45,7 +45,7 @@ class AutoStop : CommandHandler {
           if (channels.isEmpty()) {
             "Cannot find voice channel $channelName."
           } else {
-            channels.forEach { updateChannelAutoLeave(it, number) }
+            channels.forEach { updateChannelAutoStop(it, number) }
             "Will now automatically leave '$channelName' when there are $number or less people."
           }
         }

--- a/src/main/kotlin/tech/gdragon/commands/settings/AutoStop.kt
+++ b/src/main/kotlin/tech/gdragon/commands/settings/AutoStop.kt
@@ -56,10 +56,10 @@ class AutoStop : CommandHandler {
       }*/
 
     val defaultChannel = BotUtils.defaultTextChannel(event.guild) ?: event.channel
-    BotUtils.sendMessage(defaultChannel, ":no_entry_sign: _AutoLeave is currently disabled due to some bugs_")
+    BotUtils.sendMessage(defaultChannel, ":no_entry_sign: _autostop is currently disabled due to some bugs_")
   }
 
-  override fun usage(prefix: String): String = "${prefix}autoleave [Voice Channel name | 'all'] [number]"
+  override fun usage(prefix: String): String = "${prefix}autostop [Voice Channel name | 'all'] [number]"
 
-  override fun description(): String = "Sets the number of players for the bot to auto-leave a voice channel. All will apply number to all voice channels."
+  override fun description(): String = "Sets the number of players for the bot to autostop a voice channel. All will apply number to all voice channels."
 }

--- a/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
+++ b/src/main/kotlin/tech/gdragon/db/dao/DataAccessObject.kt
@@ -35,7 +35,7 @@ class Channel(id: EntityID<Long>) : LongEntity(id) {
   var name by Channels.name
   var autoRecord by Channels.autoRecord
   @Deprecated("This feature is broken", level = DeprecationLevel.ERROR)
-  var autoLeave by Channels.autoLeave
+  var autoStop by Channels.autoStop
   var settings by Settings referencedOn Channels.settings
 }
 

--- a/src/main/kotlin/tech/gdragon/db/table/Tables.kt
+++ b/src/main/kotlin/tech/gdragon/db/table/Tables.kt
@@ -33,7 +33,7 @@ object Tables {
   object Channels : LongIdTable() {
     val name = text("name")
     val autoRecord = integer("autoRecord").nullable()
-    val autoLeave = integer("autoLeave").default(1)
+    val autoStop = integer("autoStop").default(1)
     val settings = reference("settings", Settings, ReferenceOption.CASCADE)
   }
 


### PR DESCRIPTION
Early in the bot's design, for some reason I thought it was a great idea to preload every new Guild with a bunch of aliases. These aliases were pretty static, and the user did not ask for them. This led to the database getting over inflated with records, which amounted to 4x the number of Guilds.

Instead, now we just keep an Alias table of actual aliases that the users have added. Additionally, this allows us to complete the renaming of things saying "join" and "leave" to "record" and "stop" respectively.

Closes #42 