### PR TITLE
Fix Error Responses

### DIFF
--- a/Dockerfile.metabase
+++ b/Dockerfile.metabase
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre-slim
 
-ENV VERSION 0.32.1
+ENV VERSION 0.32.5
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.metabase
-    image: metabase/metabase:v0.32.1-custom
+    image: metabase/metabase:v0.32.5-custom
     environment:
       - TZ=America/Los_Angeles
       - MB_DB_FILE=/tmp/metabase.db
@@ -46,7 +46,7 @@ services:
     logging:
       <<: *logging
   datastore:
-    image: minio/minio:RELEASE.2019-03-27T22-35-21Z
+    image: minio/minio:RELEASE.2019-04-23T23-50-36Z
     command: -c "MINIO_SECRET_KEY=$$DS_SECRET_KEY MINIO_ACCESS_KEY=$$DS_ACCESS_KEY minio gateway b2"
     entrypoint: sh
     env_file:

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -4,7 +4,6 @@ import mu.KotlinLogging
 import net.dv8tion.jda.core.JDA
 import net.dv8tion.jda.core.entities.*
 import net.dv8tion.jda.core.exceptions.InsufficientPermissionException
-import net.dv8tion.jda.core.exceptions.RateLimitedException
 import org.jetbrains.exposed.sql.Between
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SqlExpressionBuilder
@@ -232,14 +231,14 @@ object BotUtils {
       try {
         bot.guild.controller
           .setNickname(bot, newNick)
-          .complete(true)
+          .queue(null, { t ->
+            logger.error(t) {
+              "Could not change nickname: $prevNick -> $newNick"
+            }
+          })
       } catch (e: InsufficientPermissionException) {
-        logger.warn {
+        logger.warn(e) {
           "Missing ${e.permission} permission to change $prevNick -> $newNick"
-        }
-      } catch (e: RateLimitedException) {
-        logger.error(e) {
-          "Could not change nickname: $prevNick -> $newNick"
         }
       }
     }

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -7,6 +7,7 @@ import io.reactivex.disposables.Disposable
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 import mu.KotlinLogging
+import mu.withLoggingContext
 import net.dv8tion.jda.core.audio.AudioReceiveHandler
 import net.dv8tion.jda.core.audio.CombinedAudio
 import net.dv8tion.jda.core.audio.UserAudio
@@ -135,7 +136,12 @@ class CombinedAudioRecorderHandler(var volume: Double, val voiceChannel: VoiceCh
       }
       ?.subscribe { _, e ->
         e?.let {
-          logger.error("An error occurred in the recording pipeline: ${it.message}", it)
+          withLoggingContext("guild" to voiceChannel.guild.name, "voice-channel" to voiceChannel.name) {
+            when (e) {
+              is IOException -> logger.warn(it) { "Error with queue file: $queueFilename" }
+              else -> logger.error(it) { "An error occurred in the recording pipeline" }
+            }
+          }
         }
       }
   }

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -158,9 +158,17 @@ class CombinedAudioRecorderHandler(var volume: Double, val voiceChannel: VoiceCh
           stream.transferTo(it)
         }
 
-        clear()
-        close()
-        File(queueFilename).delete()
+        try {
+          // TODO: Why clear file? It's gonna get deleted anyway
+          clear()
+        } catch (e: IOException) {
+          logger.warn(e) {
+            "Issue clearing queue file: $queueFilename"
+          }
+        } finally {
+          close()
+          File(queueFilename).delete()
+        }
       }
     }
 

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -79,10 +79,7 @@ class CombinedAudioRecorderHandler(var volume: Double, val voiceChannel: VoiceCh
       logger.info("{}#{}: AFK detected.", voiceChannel.guild.name, voiceChannel.name)
 
       BotUtils.sendMessage(defaultChannel, ":sleeping: _No audio detected in the last **$AFK_MINUTES** minutes, leaving **<#${voiceChannel.id}>**._")
-
-      thread(start = true) {
-        BotUtils.leaveVoiceChannel(voiceChannel, defaultChannel)
-      }
+      BotUtils.leaveVoiceChannel(voiceChannel, defaultChannel)
     }
 
     return isAfk

--- a/src/main/kotlin/tech/gdragon/listener/EventListener.kt
+++ b/src/main/kotlin/tech/gdragon/listener/EventListener.kt
@@ -203,7 +203,7 @@ class EventListener : ListenerAdapter(), KoinComponent {
     val version: String = getKoin().getProperty("VERSION", "dev")
     event
       .jda
-      .presence.game = object : Game("$version | $website", website, Game.GameType.DEFAULT) {}
+      .presence.game = object : Game("$version | $website", website, GameType.DEFAULT) {}
 
     logger.info { "ONLINE: Connected to ${event.jda.guilds.size} guilds!" }
 
@@ -212,7 +212,7 @@ class EventListener : ListenerAdapter(), KoinComponent {
     logger.info { "Add any missing Guilds to the Database..." }
     event.jda.guilds.forEach {
       transaction {
-        tech.gdragon.db.dao.Guild.findOrCreate(it.idLong, it.name, it.region.name)
+        Guild.findOrCreate(it.idLong, it.name, it.region.name)
       }
     }
   }


### PR DESCRIPTION
The bot has rollbar enabled, and has been collecting error metrics for a while
now but a lot of these errors were not being addressed.

In this PR, these were more intelligently logged and perhaps fixed:

* Issues when clearing/writing to queue files
* Creating additional threads instead of relying on JDA
* In general, add loggingContext to more areas to determine what Guild is having trouble

Closes #32