### PR TITLE
Upload to Discord if recording is small

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     logging:
       <<: *logging
   datastore:
-    image: minio/minio:RELEASE.2019-04-23T23-50-36Z
+    image: minio/minio:RELEASE.RELEASE.2019-05-02T19-07-09Z
     command: -c "MINIO_SECRET_KEY=$$DS_SECRET_KEY MINIO_ACCESS_KEY=$$DS_ACCESS_KEY minio gateway b2"
     entrypoint: sh
     env_file:

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -3,6 +3,7 @@ package tech.gdragon
 import mu.KotlinLogging
 import mu.withLoggingContext
 import net.dv8tion.jda.core.JDA
+import net.dv8tion.jda.core.MessageBuilder
 import net.dv8tion.jda.core.entities.*
 import net.dv8tion.jda.core.exceptions.InsufficientPermissionException
 import org.jetbrains.exposed.sql.Between
@@ -16,6 +17,7 @@ import tech.gdragon.db.dateTimeLiteral
 import tech.gdragon.db.table.Tables
 import tech.gdragon.listener.CombinedAudioRecorderHandler
 import tech.gdragon.listener.SilenceAudioSendHandler
+import java.io.File
 import java.util.*
 import kotlin.concurrent.schedule
 import net.dv8tion.jda.core.entities.Guild as DiscordGuild
@@ -308,5 +310,15 @@ object BotUtils {
         ?.receiveHandler as CombinedAudioRecorderHandler?
 
     handler?.volume = volume
+  }
+
+  fun uploadFile(textChannel: TextChannel, file: File) {
+    val message = MessageBuilder()
+      .append(":arrow_up: **Upload complete!**")
+      .build()
+
+    textChannel
+      .sendFile(file, message)
+      .queue()
   }
 }

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -319,6 +319,6 @@ object BotUtils {
 
     textChannel
       .sendFile(file, message)
-      .queue()
+      .complete()
   }
 }

--- a/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
+++ b/src/main/kotlin/tech/gdragon/listener/CombinedAudioRecorderHandler.kt
@@ -37,7 +37,8 @@ class CombinedAudioRecorderHandler(var volume: Double, val voiceChannel: VoiceCh
     private const val AFK_MINUTES = 2
     private const val AFK_LIMIT = (AFK_MINUTES * 60 * 1000) / 20                      // 2 minutes in ms over 20ms increments
     private const val MAX_RECORDING_MB = 110
-    private const val MAX_RECORDING_SIZE = MAX_RECORDING_MB * 1024 * 1024   // 8MB
+    private const val MAX_RECORDING_SIZE = MAX_RECORDING_MB * 1024 * 1024   // 110MB
+    private const val DISCORD_MAX_RECORDING_SIZE = 8 * 1024 * 1024          // 8MB
     private const val BUFFER_TIMEOUT = 200L                                 // 200 milliseconds
     private const val BUFFER_MAX_COUNT = 8
     private const val BITRATE = 128                                         // 128 kbps
@@ -226,6 +227,10 @@ class CombinedAudioRecorderHandler(var volume: Double, val voiceChannel: VoiceCh
   }
 
   private fun uploadRecording(recording: File, voiceChannel: VoiceChannel?, channel: TextChannel) {
+    if (recording.length() < DISCORD_MAX_RECORDING_SIZE) {
+      BotUtils.uploadFile(channel, recording)
+    }
+
     if (recording.length() < MAX_RECORDING_SIZE) {
       val recordingKey = "/${channel.guild?.id}/${recording.name}"
       val result = datastore.upload(recordingKey, recording)


### PR DESCRIPTION
This used to be the default behaviour but I removed it for some reason that I
no longer remember. Adding this back is super trivial.

Essentially, if the recording is less than 8MB, upload to Discord then upload
to Minio. Since we delete the file after the upload to Minio is complete, the
upload to Discord is a blocking operation, as I want to make sure that succeeds
before deleting the file.

Closes #99