### PR TITLE
Add "Leave After" config option

### DIFF
--- a/src/main/kotlin/tech/gdragon/App.kt
+++ b/src/main/kotlin/tech/gdragon/App.kt
@@ -17,7 +17,7 @@ import kotlin.concurrent.scheduleAtFixedRate
 
 val logger = KotlinLogging.logger { }
 
-fun main(args: Array<String>) {
+fun main() {
   val app = startKoin {
     printLogger(Level.INFO)
     fileProperties("/defaults.properties")

--- a/src/main/kotlin/tech/gdragon/App.kt
+++ b/src/main/kotlin/tech/gdragon/App.kt
@@ -32,7 +32,9 @@ fun main(args: Array<String>) {
   logger.info("Starting background process to remove unused Guilds.")
   Timer("remove-old-guilds", true)
     .scheduleAtFixedRate(0L, Duration.ofDays(1L).toMillis()) {
-      BotUtils.leaveAncientGuilds(app.koin.get<Bot>().api)
+      val jda = app.koin.get<Bot>().api
+      val afterDays = app.koin.getProperty("BOT_LEAVE_GUILD_AFTER", 30)
+      BotUtils.leaveAncientGuilds(jda, afterDays)
     }
 
   HttpServer()

--- a/src/main/kotlin/tech/gdragon/App.kt
+++ b/src/main/kotlin/tech/gdragon/App.kt
@@ -34,7 +34,13 @@ fun main(args: Array<String>) {
     .scheduleAtFixedRate(0L, Duration.ofDays(1L).toMillis()) {
       val jda = app.koin.get<Bot>().api
       val afterDays = app.koin.getProperty("BOT_LEAVE_GUILD_AFTER", 30)
-      BotUtils.leaveAncientGuilds(jda, afterDays)
+
+      if(afterDays <= 0) {
+        logger.info { "Disabling remove-old-guilds Timer." }
+        this.cancel()
+      } else {
+        BotUtils.leaveAncientGuilds(jda, afterDays)
+      }
     }
 
   HttpServer()

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -261,15 +261,16 @@ object BotUtils {
   fun voiceChannelSize(voiceChannel: VoiceChannel?): Int = voiceChannel?.members?.count() ?: 0
 
   /**
-   * Leaves any Guild that hasn't been active in the past 30 days.
+   * Leaves any Guild that hasn't been active in the past `afterDays` days.
    *
    * In the past, I've been deleting the Guild from the database, but that makes things annoying when you rejoin.
    * For now, we'll just be leaving a Guild, but keeping the settings.
    */
-  fun leaveAncientGuilds(jda: JDA) {
+  fun leaveAncientGuilds(jda: JDA, afterDays: Int) {
+    logger.info { "Leaving all Guilds that haven't been active in the past $afterDays days." }
     val op: SqlExpressionBuilder.() -> Op<Boolean> = {
       val now = DateTime.now()
-      not(Between(Tables.Guilds.lastActiveOn, dateTimeLiteral(now.minusDays(30)), dateTimeLiteral(now)))
+      not(Between(Tables.Guilds.lastActiveOn, dateTimeLiteral(now.minusDays(afterDays)), dateTimeLiteral(now)))
     }
 
     // Find all ancient guilds and ask the Bot to leave them


### PR DESCRIPTION
Add a configuration property for the inactivity period before leaving a guild.
This was hardcoded to 30 days, but it is now configurable, if configuration is
missing, the default is still 30 days. If configured with days less than 1, then
the bot will not leave any server despite the number of inactive days.

Upcoming PR will address whitelisting of specific Guilds, preventing the bot from
leaving a Guild.

Closes #105