### PR TITLE
Whitelist Guilds

### DIFF
--- a/src/main/kotlin/tech/gdragon/App.kt
+++ b/src/main/kotlin/tech/gdragon/App.kt
@@ -45,7 +45,7 @@ fun main() {
           .filter(String::isNotEmpty)
           .map(String::toLong)
 
-        BotUtils.leaveAncientGuilds(jda, afterDays, whitelist)
+        BotUtils.leaveInactiveGuilds(jda, afterDays, whitelist)
       }
     }
 

--- a/src/main/kotlin/tech/gdragon/App.kt
+++ b/src/main/kotlin/tech/gdragon/App.kt
@@ -1,4 +1,5 @@
 @file:JvmName("App")
+
 package tech.gdragon
 
 import mu.KotlinLogging
@@ -35,11 +36,16 @@ fun main() {
       val jda = app.koin.get<Bot>().api
       val afterDays = app.koin.getProperty("BOT_LEAVE_GUILD_AFTER", 30)
 
-      if(afterDays <= 0) {
+      if (afterDays <= 0) {
         logger.info { "Disabling remove-old-guilds Timer." }
         this.cancel()
       } else {
-        BotUtils.leaveAncientGuilds(jda, afterDays)
+        val whitelist = app.koin.getProperty("BOT_GUILD_WHITELIST", "")
+          .split(",")
+          .filter(String::isNotEmpty)
+          .map(String::toLong)
+
+        BotUtils.leaveAncientGuilds(jda, afterDays, whitelist)
       }
     }
 

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -265,7 +265,7 @@ object BotUtils {
    * In the past, I've been deleting the Guild from the database, but that makes things annoying when you rejoin.
    * For now, we'll just be leaving a Guild, but keeping the settings.
    */
-  fun leaveAncientGuilds(jda: JDA, afterDays: Int, whitelist: List<Long>) {
+  fun leaveInactiveGuilds(jda: JDA, afterDays: Int, whitelist: List<Long>) {
     logger.info { "Leaving all Guilds that haven't been active in the past $afterDays days." }
     val op: SqlExpressionBuilder.() -> Op<Boolean> = {
       val now = DateTime.now()

--- a/src/main/kotlin/tech/gdragon/BotUtils.kt
+++ b/src/main/kotlin/tech/gdragon/BotUtils.kt
@@ -13,7 +13,6 @@ import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.joda.time.DateTime
 import tech.gdragon.db.dao.Guild
-import tech.gdragon.db.dateTimeLiteral
 import tech.gdragon.db.table.Tables.Guilds
 import tech.gdragon.listener.CombinedAudioRecorderHandler
 import tech.gdragon.listener.SilenceAudioSendHandler
@@ -266,7 +265,7 @@ object BotUtils {
    * In the past, I've been deleting the Guild from the database, but that makes things annoying when you rejoin.
    * For now, we'll just be leaving a Guild, but keeping the settings.
    */
-  fun leaveAncientGuilds(jda: JDA, afterDays: Int, whitelist: Array<Long>) {
+  fun leaveAncientGuilds(jda: JDA, afterDays: Int, whitelist: List<Long>) {
     logger.info { "Leaving all Guilds that haven't been active in the past $afterDays days." }
     val op: SqlExpressionBuilder.() -> Op<Boolean> = {
       val now = DateTime.now()


### PR DESCRIPTION
To prevent the bot from leaving certain guilds despite their activity, a
configuration variable has been added.

We've added `BOT_GUILD_WHITELIST`, but because Koin freaks out in certain cases,
we must ensure that if there's only one guild that this variable ends with a comma.

```bash
export BOT_GUILD_WHITELIST=333055724198559745,
```

I know... silly workaround but y'know the alternative is to handroll stuff...

Additionally, there was an issue with leaving inactive guilds, so that was fixed. Currently, a lot more guilds are marked as active when in fact they are not.

Closes #106